### PR TITLE
Http Parsing

### DIFF
--- a/docs/mapping-install.md
+++ b/docs/mapping-install.md
@@ -69,6 +69,11 @@ sudo add-apt-repository ppa:adrozdoff/cmake
 sudo apt-get update
 ```
 
+### For Ubuntu ≤ 17.10
+```
+sudo add-apt-repository ppa:gezakovacs/poco
+sudo apt-get update
+```
 
 ### Install Packages:
 ```
@@ -101,7 +106,8 @@ apt-get install --yes \
     valgrind \
     r-cran-rcpp \
     libpqxx-dev \
-    libgdal-dev
+    libgdal-devs \
+    libpoco-dev
 ```
 
 ## Checkout MAPPING

--- a/docs/mapping-install.md
+++ b/docs/mapping-install.md
@@ -106,7 +106,7 @@ apt-get install --yes \
     valgrind \
     r-cran-rcpp \
     libpqxx-dev \
-    libgdal-devs \
+    libgdal-dev \
     libpoco-dev
 ```
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -248,6 +248,11 @@ find_package(LibArchive REQUIRED)
 target_link_libraries(mapping_core_base_lib ${LibArchive_LIBRARIES})
 target_include_directories(mapping_core_base_lib PRIVATE ${LibArchive_INCLUDE_DIRS})
 
+#Poco
+include_directories(/usr/include/Poco/)
+link_directories(/usr/lib/)
+target_link_libraries(mapping_core_base_lib PocoFoundation)
+
 ## OpenCl
 find_package(OpenCL REQUIRED)
 # target_link_libraries(mapping_core_base_lib OpenCL::OpenCL) # works only with CMAKE 3.7

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -249,9 +249,8 @@ target_link_libraries(mapping_core_base_lib ${LibArchive_LIBRARIES})
 target_include_directories(mapping_core_base_lib PRIVATE ${LibArchive_INCLUDE_DIRS})
 
 #Poco
-include_directories(/usr/include/Poco/)
-link_directories(/usr/lib/)
 target_link_libraries(mapping_core_base_lib PocoFoundation)
+target_link_libraries(mapping_core_base_lib PocoNet)
 
 ## OpenCl
 find_package(OpenCL REQUIRED)

--- a/src/services/httpparsing.cpp
+++ b/src/services/httpparsing.cpp
@@ -36,55 +36,6 @@ static std::string getFCGIParam(FCGX_Request &request, std::string key) {
 	return string;
 }
 
-/*
- * Converts a hex value to the corresponding character representation.
- */
-static char hexvalue(char c) {
-	if (c >= '0' && c <= '9')
-		return c - '0';
-	if (c >= 'a' && c <= 'f')
-		return c - 'a' + 10;
-	if (c >= 'A' && c <= 'F')
-		return c - 'A' + 10;
-	return 0;
-}
-
-static void trim(std::string& str, bool left = true, bool right = true, const std::string& delimiters = " \n\r\t") {
-	if (left)
-		str.erase(0, str.find_first_not_of(delimiters));
-	if (right)
-		str.erase(str.find_last_not_of(delimiters) + 1);
-}
-
-/**
- * Decodes an URL
- */
-static bool ishex(char c) {
-	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
-}
-
-static std::string urldecode(const std::string& str) {
-	const int len = str.length();
-
-	std::vector<char> buffer;
-	buffer.reserve(len);
-
-	int pos = 0;
-	while (pos < len) {
-		const char c = str[pos];
-		if (c == '%' && pos + 2 < len && ishex(str[pos + 1]) && ishex(str[pos + 2])) {
-			char out = 16 * hexvalue(str[pos + 1]) + hexvalue(str[pos + 2]);
-			buffer.push_back(out);
-			pos += 3;
-		} else {
-			buffer.push_back(c);
-			pos++;
-		}
-	}
-
-	return std::string(buffer.begin(), buffer.end());
-}
-
 /**
  * Gets the data from a POST request
  */
@@ -97,36 +48,6 @@ static std::string getPostData(std::istream& in, int content_length) {
 	std::string query(buf, buf + content_length);
 	delete[] buf;
 	return query;
-}
-
-static void parseKeyValuePair(const std::string& q, std::map<std::string, std::string>& kvp, bool unescape = false, const std::string& delim = "=") {
-	std::string::size_type sep = q.find_first_of(delim);
-
-	std::string key, val;
-
-	if (sep == std::string::npos) {
-        Poco::URI::decode(q, key, true);
-		val = ""; // Empty value
-	} else {
-		Poco::URI::decode(q.substr(0, sep), key, true);
-        Poco::URI::decode(q.substr(sep + 1, q.length() - (sep + 1)), val, true);
-        trim(val);
-	}
-
-	trim(key);
-	if (key.empty())
-		return;
-	std::transform(key.begin(), key.end(), key.begin(), ::tolower);
-
-	if (unescape && val.size() >= 2) {
-
-		if (val.front() == '\"' && val.back() == '\"') {
-			val.erase(0, 1);
-			val.erase(val.length() - 1);
-		}
-	}
-
-	kvp[key] = val;
 }
 
 /**
@@ -144,7 +65,6 @@ void parseQuery(const std::string& query, Parameters &params) {
         std::transform(parameter.first.begin(), parameter.first.end(), parameter.first.begin(), ::tolower);
 		params.insert(std::make_pair(parameter.first, parameter.second));
 	}
-
 }
 
 /**
@@ -155,290 +75,13 @@ static void parsePostUrlEncoded(Parameters &params, std::istream &in, int conten
 	parseQuery(query, params);
 }
 
-bool parseMultipartParameter(const std::string& line, std::map<std::string, std::string>& params) {
-	std::string::size_type delim = line.find_first_of(':');
-	if (delim != std::string::npos) {
-		std::string param = line.substr(0, delim);
-		trim(param);
-		std::transform(param.begin(), param.end(), param.begin(), tolower);
-		if (param == "content-type" || param == "content-disposition" || param == "content-transfer-encoding") {
-			std::string val = line.substr(delim + 1);
-			trim(val);
-			if (param == "content-transfer-encoding") {
-				std::transform(val.begin(), val.end(), val.begin(), tolower);
-			}
-			params[param] = val;
-			return true;
-		}
-	}
-	return false;
-}
-
-static void parseMultipartSubBoundary(Parameters &params, std::istream& in, std::map<std::string, std::string>& pars);
-
-static void parseMultipartBoundary(Parameters &params, std::istream& in, const std::string& boundary) {
-
-	const std::string boundary_start = "--" + boundary;
-	const std::string boundary_end = boundary_start + "--";
-
-	// Begin parsing the boundaries. Since the RFC does not mention the explicit requirement of having line-breaks between
-	// the boundary tokens (--boundary,--boundary--), this is done by character comparison.
-
-	std::size_t match_size = 0;
-	std::string buf;
-
-	bool found_end = false;
-	bool in_boundary = false;
-	while (in.good() && !in.eof()) {
-		char c = in.get();
-		buf.push_back(c);
-		if (boundary_start.length() > match_size) {
-			// Seek the start
-			if (boundary_start[match_size] == c) {
-				match_size++;
-
-			} else
-				match_size = 0;
-			if (match_size == boundary_start.length()) {
-				// Found boundary start
-				if (!buf.empty() && in_boundary) {
-					buf.erase(buf.length() - boundary_start.length()); // Cut the boundary string
-					std::stringstream sub_boundary_stream;
-					sub_boundary_stream << buf;
-					std::map<std::string, std::string> pars;
-					parseMultipartSubBoundary(params, sub_boundary_stream, pars);
-				}
-				in_boundary = true;
-				buf.clear();
-			}
-		} else if (boundary_end.length() > match_size) {
-			// Seek the start
-			if (boundary_end[match_size] == c) {
-				match_size++;
-			} else
-				match_size = 0;
-			if (match_size == boundary_end.length()) {
-				// Found boundary end, skip the epilogue
-				found_end = true;
-				break;
-			}
-		}
-	}
-	buf.clear();
-	if (!found_end) {
-		throw std::runtime_error("Unexpected end of stream.");
-	}
-
-}
-
-static void parseMultipartSubBoundary(Parameters &params, std::istream& in, std::map<std::string, std::string>& pars) {
-
-	// see RFC 1341 ch 7.2.1
-	// This method may be used as recursive in order to support nested sub-boundaries.
-	std::string body;
-	std::vector<std::string> potential_body_lines;
-	bool in_body = false;
-
-	while (in.good() && !in.eof()) {
-		std::string line;
-		do { // std::getline doesn't seem to work here for some reason.
-			char c=in.get();
-			if(c < 0 || c == '\0' || c == '\n' || c=='\r') {
-				break;
-			}
-			line += c;
-		} while(in);
-
-
-		// Parse parameters first, then body.
-		if (!in_body && !parseMultipartParameter(line, pars)) {
-			// We found a line that is not a parameter. Add the raw line to the potential body line buffer.
-			// This guarantees that empty lines will be preserved as long as the body format supports this.
-			potential_body_lines.push_back(line);
-			if (line.find_first_not_of(" \n\r\t") != std::string::npos) {
-				// We found a line that is neither a parameter nor an empty line. This guarantees we are in the body segment already.
-				in_body = true;
-			}
-
-		} else {
-			// Another parameter.
-			if (!in_body) {
-				// Clear the body line buffer if there are only empty lines.
-				potential_body_lines.clear();
-			} else
-				potential_body_lines.push_back(line);
-		}
-	}
-
-	// Build the body based on the parsed parameters
-	for (auto& line : potential_body_lines) {
-		const std::string& enc = pars["content-transfer-encoding"];
-		if (enc == "base64") {
-			trim(line);
-			body += base64_decode(line);
-		} else if (enc.empty()) { // Default behaviour
-			body += line + "\n";
-		} else
-			throw ArgumentException("Unsupported transfer encoding.");
-	}
-	potential_body_lines.clear();
-
-	// Now check if this is a multipart message
-	{
-		std::string boundary_start;
-		std::string boundary_end;
-		std::string::size_type cur, last = 0;
-
-		std::string& params_str = pars["content-type"];
-		std::map<std::string, std::string> cparams;
-
-		while ((cur = params_str.find_first_of(";", last)) != std::string::npos) {
-			std::string sub = params_str.substr(last, cur - last);
-			if (last > 0) {
-				parseKeyValuePair(sub, cparams, true);
-			}
-			last = cur + 1;
-		}
-
-		if (last < params_str.length()) {
-			std::string sub = params_str.substr(last, params_str.length() - last);
-			parseKeyValuePair(sub, cparams, true);
-		}
-
-		if (cparams.find("boundary") != cparams.end()) {
-			std::string boundary = cparams["boundary"];
-			trim(boundary, false, true); // RFC specifies only right whitespace removal.
-			if (boundary.length() >= 70) // RFC explicitly restricts this to 70 characters.
-				throw ArgumentException("Boundary length exceeded.");
-
-			std::stringstream bodyStream;
-			bodyStream << body;
-			body.clear();
-			parseMultipartBoundary(params, bodyStream, boundary);
-
-			return;
-
-		}
-
-	}
-
-	// If this is not a multipart message treat it as any regular post message (that may contain form data as well).
-
-	const std::string& content_disposition = pars["content-disposition"];
-	if(!content_disposition.empty()) {
-		std::string::size_type last = 0;
-		std::string::size_type cur;
-
-		std::map<std::string, std::string> cdparams;
-		std::string type;
-
-		while ((cur = content_disposition.find_first_of(";", last)) != std::string::npos) {
-			std::string sub = content_disposition.substr(last, cur - last);
-			if(last == 0) {
-				type = sub;
-				std::transform(type.begin(), type.end(), type.begin(), tolower);
-			}
-			else
-				parseKeyValuePair(sub, cdparams, true, "=");
-			last = cur + 1;
-		}
-
-		if (last < content_disposition.length()) {
-			std::string sub = content_disposition.substr(last, content_disposition.length() - last);
-			parseKeyValuePair(sub, cdparams, true, "=");
-		}
-
-		if(type == "form-data") {
-
-			if(cdparams["name"].empty()) {
-				throw ArgumentException("Missing form-data name parameter.");
-			}
-
-			std::string name = cdparams["name"];
-/*
-			if(!cdparams["filename"].empty()) {
-
-				// Extend HTTPService::Params with information about where to save (/tmp by default?)
-				const std::string directory = Configuration::get("multipart_default_file_directory", "/tmp");
-				std::string filename = directory + "/" +cdparams["filename"];
-
-				std::ofstream of(filename);
-				if(!of.good()) {
-					throw ArgumentException("Cannot open file " + filename + " for writing");
-				}
-
-				of << body;
-				of.close();
-
-				params[name] = filename;
-			}
-			else */{
-				// Store file in memory (string encoded into HTTPService::Params? What about binary data?)
-				params.insert(std::make_pair(name, body));
-
-			}
-
-		}
-		else {
-			throw ArgumentException("Unsupported content disposition type.");
-		}
-	}
-
-}
-
-
-
-
 /**
- * Parses a multipart POST request
+ * Get Reader for multipart data.
+ * Parsing multipart post data is not supported right now.
  */
-void parseMultipartPostData(Parameters &params, std::istream &in) {
+std::unique_ptr<Poco::Net::MultipartReader> getMultipartPostDataReader(Parameters &params, std::istream &in) {
 
-	// This is merely a wrapper around parseMultipartSubBoundary() that will forward the
-	// content type provided in the system environment variables.
-
-	// The standard describes multipart messages can be nested, so the method below will
-	// treat each single boundary (that is in fact considered a "part") as if it was sent un-nested.
-
-	// Ultimately, this method will supersede parsePostData() at some time.
-
-	// const std::streamsize max_message_length = 1024 * 1024 * 24; // Restrict the maximum message size
-	//std::map<std::string, std::string> pars;
-
-	// HTTP header fields are always case-insensitive (RFC 2616 ch. 4.2)
-	//pars["content-type"] = getenv_str("CONTENT_TYPE", true);
-	//parseMultipartSubBoundary(params, in, pars);
-
-
-	Poco::Net::MultipartReader mr(in);
-
-	while(mr.hasNextPart()){
-		Poco::Net::MessageHeader header;
-		mr.nextPart(header);
-
-        //the stream has to completely read (Poco docs)
-        std::ostringstream os;
-        mr.stream() >> os.rdbuf();
-        std::string s = os.str();
-        trim(s);
-
-        if(!header.has("Content-Disposition"))
-            continue;
-
-		std::string value;
-		Poco::Net::NameValueCollection parameters;
-		header.splitParameters(header["Content-Disposition"], value, parameters);
-
-
-		if(value == "form-data") {
-            if(parameters.has("name"))
-			    params.insert(std::make_pair(parameters["name"], s));
-            else
-                throw ArgumentException("form-data is missing name.");
-		}
-	}
-
-	return;
+    return make_unique<Poco::Net::MultipartReader>(in);
 }
 
 /**
@@ -461,7 +104,7 @@ void parsePostData(Parameters &params, std::istream &in) {
 	if (content_type == "application/x-www-form-urlencoded") {
 		parsePostUrlEncoded(params, in, content_length);
 	} else if (content_type.find("multipart/form-data") != std::string::npos || content_type.find("multipart/mixed") != std::string::npos) {
-        throw ArgumentException("For multipart POST request call the special function.");
+        throw ArgumentException("For multipart POST request call getMultipartPostDataReader (offers no parsing).");
 	} else
 		throw ArgumentException("Unknown content type in POST request.");
 }
@@ -473,7 +116,6 @@ void parseGetData(Parameters &params) {
 	std::string query_string = getenv_str("QUERY_STRING");
 	parseQuery(query_string, params);
 }
-
 
 /**
  * Parses POST data from a HTTP request FCGI
@@ -497,7 +139,7 @@ void parsePostData(Parameters &params, std::istream &in, FCGX_Request &request) 
 	if (content_type == "application/x-www-form-urlencoded") {
 		parsePostUrlEncoded(params, in, content_length);
 	} else if (content_type.find("multipart/form-data") != std::string::npos || content_type.find("multipart/mixed") != std::string::npos) {
-        throw ArgumentException("For multipart POST request call the special function.");
+        throw ArgumentException("For multipart POST request call getMultipartPostDataReader (offers no parsing).");
 	} else
 		throw ArgumentException("Unknown content type in POST request.");
 }

--- a/src/services/httpparsing.cpp
+++ b/src/services/httpparsing.cpp
@@ -9,6 +9,7 @@
 #include "util/make_unique.h"
 #include "util/base64.h"
 #include <Poco/URI.h>
+#include <Poco/Net/MultipartReader.h>
 
 
 /**
@@ -103,12 +104,12 @@ static void parseKeyValuePair(const std::string& q, std::map<std::string, std::s
 	std::string key, val;
 
 	if (sep == std::string::npos) {
-		key = q;
+        Poco::URI::decode(q, key, true);
 		val = ""; // Empty value
 	} else {
-		key = urldecode(q.substr(0, sep));
-		val = urldecode(q.substr(sep + 1, q.length() - (sep + 1)));
-		trim(val);
+		Poco::URI::decode(q.substr(0, sep), key, true);
+        Poco::URI::decode(q.substr(sep + 1, q.length() - (sep + 1)), val, true);
+        trim(val);
 	}
 
 	trim(key);
@@ -154,7 +155,7 @@ static void parsePostUrlEncoded(Parameters &params, std::istream &in, int conten
 }
 
 bool parseMultipartParameter(const std::string& line, std::map<std::string, std::string>& params) {
-	std::string::size_type delim = line.find_first_of(":");
+	std::string::size_type delim = line.find_first_of(':');
 	if (delim != std::string::npos) {
 		std::string param = line.substr(0, delim);
 		trim(param);

--- a/src/services/httpparsing.cpp
+++ b/src/services/httpparsing.cpp
@@ -77,7 +77,7 @@ static void parsePostUrlEncoded(Parameters &params, std::istream &in, int conten
 
 /**
  * Get Reader for multipart data.
- * Parsing multipart post data is not supported right now.
+ * Reading values from multipart data has to be done manually right now.
  */
 std::unique_ptr<Poco::Net::MultipartReader> getMultipartPostDataReader(Parameters &params, std::istream &in) {
 
@@ -104,7 +104,7 @@ void parsePostData(Parameters &params, std::istream &in) {
 	if (content_type == "application/x-www-form-urlencoded") {
 		parsePostUrlEncoded(params, in, content_length);
 	} else if (content_type.find("multipart/form-data") != std::string::npos || content_type.find("multipart/mixed") != std::string::npos) {
-        throw ArgumentException("For multipart POST request call getMultipartPostDataReader (offers no parsing).");
+        throw ArgumentException("For multipart POST request call getMultipartPostDataReader.");
 	} else
 		throw ArgumentException("Unknown content type in POST request.");
 }
@@ -139,7 +139,7 @@ void parsePostData(Parameters &params, std::istream &in, FCGX_Request &request) 
 	if (content_type == "application/x-www-form-urlencoded") {
 		parsePostUrlEncoded(params, in, content_length);
 	} else if (content_type.find("multipart/form-data") != std::string::npos || content_type.find("multipart/mixed") != std::string::npos) {
-        throw ArgumentException("For multipart POST request call getMultipartPostDataReader (offers no parsing).");
+        throw ArgumentException("For multipart POST request call getMultipartPostDataReader.");
 	} else
 		throw ArgumentException("Unknown content type in POST request.");
 }

--- a/src/services/httpparsing.h
+++ b/src/services/httpparsing.h
@@ -10,5 +10,6 @@ void parsePostData(Parameters &params, std::istream &in);
 
 void parseGetData(Parameters &params, FCGX_Request &request);
 void parsePostData(Parameters &params, std::istream &in, FCGX_Request &request);
+void parseMultipartPostData(Parameters &params, std::istream &in);
 
 #endif

--- a/src/services/httpparsing.h
+++ b/src/services/httpparsing.h
@@ -3,6 +3,7 @@
 
 #include "services/httpservice.h"
 #include <fcgio.h>
+#include <Poco/Net/MultipartReader.h>
 
 void parseQuery(const std::string& query, Parameters &params);
 void parseGetData(Parameters &params);
@@ -10,6 +11,6 @@ void parsePostData(Parameters &params, std::istream &in);
 
 void parseGetData(Parameters &params, FCGX_Request &request);
 void parsePostData(Parameters &params, std::istream &in, FCGX_Request &request);
-void parseMultipartPostData(Parameters &params, std::istream &in);
+std::unique_ptr<Poco::Net::MultipartReader> getMultipartPostDataReader(Parameters &params, std::istream &in);
 
 #endif

--- a/src/util/parameters.cpp
+++ b/src/util/parameters.cpp
@@ -13,7 +13,7 @@ bool Parameters::hasParam(const std::string& key) const {
 const std::string &Parameters::get(const std::string &name) const {
     auto it = find(name);
     if (it == end())
-        throw ArgumentException(concat("No configuration found for key ", name));
+        throw ArgumentException(concat("No parameter found for key ", name));
     return it->second;
 }
 
@@ -27,7 +27,7 @@ const std::string &Parameters::get(const std::string &name, const std::string &d
 int Parameters::getInt(const std::string &name) const {
     auto it = find(name);
     if (it == end())
-        throw ArgumentException(concat("No configuration found for key ", name));
+        throw ArgumentException(concat("No parameter found for key ", name));
     return parseInt(it->second);
 }
 
@@ -41,7 +41,7 @@ int Parameters::getInt(const std::string &name, const int defaultValue) const {
 long Parameters::getLong(const std::string &name) const {
     auto it = find(name);
     if (it == end())
-        throw ArgumentException(concat("No configuration found for key ", name));
+        throw ArgumentException(concat("No parameter found for key ", name));
     return parseLong(it->second);
 }
 
@@ -55,7 +55,7 @@ long Parameters::getLong(const std::string &name, const long defaultValue) const
 bool Parameters::getBool(const std::string &name) const {
     auto it = find(name);
     if (it == end())
-        throw ArgumentException(concat("No configuration found for key ", name));
+        throw ArgumentException(concat("No parameter found for key ", name));
     return parseBool(it->second);
 }
 
@@ -72,10 +72,133 @@ Parameters Parameters::getPrefixedParameters(const std::string &prefix) {
         auto &key = it.first;
         if (key.length() > prefix.length() && key.substr(0, prefix.length()) == prefix) {
             result.insert(std::make_pair(key.substr(prefix.length()), it.second));
-            //result[ key.substr(prefix.length()) ] = it.second;
         }
     }
     return result;
+}
+
+std::vector<std::string> Parameters::getAll(const std::string &name) const {
+    std::vector<std::string> vec;
+
+    auto iteratorPair = this->equal_range(name);
+    for(auto it = iteratorPair.first; it != iteratorPair.second; it++){
+        vec.push_back(it->second);
+    }
+
+    return vec;
+}
+
+std::vector<int> Parameters::getAllInt(const std::string &name) const {
+    std::vector<int> vec;
+
+    auto iteratorPair = this->equal_range(name);
+    for(auto it = iteratorPair.first; it != iteratorPair.second; it++){
+        vec.push_back(parseInt(it->second));
+    }
+
+    return vec;
+}
+
+std::vector<long> Parameters::getAllLong(const std::string &name) const {
+    std::vector<long> vec;
+
+    auto iteratorPair = this->equal_range(name);
+    for(auto it = iteratorPair.first; it != iteratorPair.second; it++){
+        vec.push_back(parseLong(it->second));
+    }
+
+    return vec;
+}
+
+std::vector<bool> Parameters::getAllBool(const std::string &name) const {
+    std::vector<bool> vec;
+
+    auto iteratorPair = this->equal_range(name);
+    for(auto it = iteratorPair.first; it != iteratorPair.second; it++){
+        vec.push_back(parseBool(it->second));
+    }
+
+    return vec;
+}
+
+const std::string &Parameters::getLast(const std::string &name) const {
+    auto range = equal_range(name);
+    if(range.first == range.second)
+        throw ArgumentException(concat("No parameter found for key ", name));
+
+    auto it = range.second;
+    it--;
+    return it->second;
+}
+
+const std::string &Parameters::getLast(const std::string &name, const std::string &defaultValue) const {
+    auto range = equal_range(name);
+    if(range.first == range.second)
+        return defaultValue;
+
+    auto it = range.second;
+    it--;
+    return it->second;
+}
+
+int Parameters::getLastInt(const std::string &name) const {
+    auto range = equal_range(name);
+    if(range.first == range.second)
+        throw ArgumentException(concat("No parameter found for key ", name));
+
+    auto it = range.second;
+    it--;
+    return parseInt(it->second);
+}
+
+int Parameters::getLastInt(const std::string &name, int defaultValue) const {
+    auto range = equal_range(name);
+    if(range.first == range.second)
+        return defaultValue;
+
+    auto it = range.second;
+    it--;
+    return parseInt(it->second);
+}
+
+long Parameters::getLastLong(const std::string &name) const {
+    auto range = equal_range(name);
+    if(range.first == range.second)
+        throw ArgumentException(concat("No parameter found for key ", name));
+
+    auto it = range.second;
+    it--;
+    return parseLong(it->second);
+}
+
+long Parameters::getLastLong(const std::string &name, long defaultValue) const {
+    auto range = equal_range(name);
+    if(range.first == range.second)
+        return defaultValue;
+
+    auto it = range.second;
+    it--;
+    return parseLong(it->second);
+}
+
+bool Parameters::getLastBool(const std::string &name) const {
+    auto range = equal_range(name);
+    if(range.first == range.second)
+        throw ArgumentException(concat("No parameter found for key ", name));
+
+    auto it = range.second;
+    it--;
+    return parseBool(it->second);
+}
+
+bool Parameters::getLastBool(const std::string &name, bool defaultValue) const {
+    auto range = equal_range(name);
+    if(range.first == range.second)
+        return defaultValue;
+
+    auto it = range.second;
+    it--;
+    return parseBool(it->second);
 }
 
 

--- a/src/util/parameters.cpp
+++ b/src/util/parameters.cpp
@@ -11,58 +11,82 @@ bool Parameters::hasParam(const std::string& key) const {
 }
 
 const std::string &Parameters::get(const std::string &name) const {
-    auto it = find(name);
-    if (it == end())
+    auto range = equal_range(name);
+    if(range.first == range.second)
         throw ArgumentException(concat("No parameter found for key ", name));
+
+    auto it = range.second;
+    it--;
     return it->second;
 }
 
 const std::string &Parameters::get(const std::string &name, const std::string &defaultValue) const {
-    auto it = find(name);
-    if (it == end())
+    auto range = equal_range(name);
+    if(range.first == range.second)
         return defaultValue;
+
+    auto it = range.second;
+    it--;
     return it->second;
 }
 
 int Parameters::getInt(const std::string &name) const {
-    auto it = find(name);
-    if (it == end())
+    auto range = equal_range(name);
+    if(range.first == range.second)
         throw ArgumentException(concat("No parameter found for key ", name));
+
+    auto it = range.second;
+    it--;
     return parseInt(it->second);
 }
 
 int Parameters::getInt(const std::string &name, const int defaultValue) const {
-    auto it = find(name);
-    if (it == end())
+    auto range = equal_range(name);
+    if(range.first == range.second)
         return defaultValue;
+
+    auto it = range.second;
+    it--;
     return parseInt(it->second);
 }
 
 long Parameters::getLong(const std::string &name) const {
-    auto it = find(name);
-    if (it == end())
+    auto range = equal_range(name);
+    if(range.first == range.second)
         throw ArgumentException(concat("No parameter found for key ", name));
+
+    auto it = range.second;
+    it--;
     return parseLong(it->second);
 }
 
 long Parameters::getLong(const std::string &name, const long defaultValue) const {
-    auto it = find(name);
-    if (it == end())
+    auto range = equal_range(name);
+    if(range.first == range.second)
         return defaultValue;
+
+    auto it = range.second;
+    it--;
     return parseLong(it->second);
 }
 
 bool Parameters::getBool(const std::string &name) const {
-    auto it = find(name);
-    if (it == end())
+    auto range = equal_range(name);
+    if(range.first == range.second)
         throw ArgumentException(concat("No parameter found for key ", name));
+
+    auto it = range.second;
+    it--;
     return parseBool(it->second);
 }
 
 bool Parameters::getBool(const std::string &name, const bool defaultValue) const {
-    auto it = find(name);
-    if (it == end())
+    auto range = equal_range(name);
+    if(range.first == range.second)
         return defaultValue;
+
+    auto it = range.second;
+    it--;
     return parseBool(it->second);
 }
 
@@ -120,87 +144,6 @@ std::vector<bool> Parameters::getAllBool(const std::string &name) const {
 
     return vec;
 }
-
-const std::string &Parameters::getLast(const std::string &name) const {
-    auto range = equal_range(name);
-    if(range.first == range.second)
-        throw ArgumentException(concat("No parameter found for key ", name));
-
-    auto it = range.second;
-    it--;
-    return it->second;
-}
-
-const std::string &Parameters::getLast(const std::string &name, const std::string &defaultValue) const {
-    auto range = equal_range(name);
-    if(range.first == range.second)
-        return defaultValue;
-
-    auto it = range.second;
-    it--;
-    return it->second;
-}
-
-int Parameters::getLastInt(const std::string &name) const {
-    auto range = equal_range(name);
-    if(range.first == range.second)
-        throw ArgumentException(concat("No parameter found for key ", name));
-
-    auto it = range.second;
-    it--;
-    return parseInt(it->second);
-}
-
-int Parameters::getLastInt(const std::string &name, int defaultValue) const {
-    auto range = equal_range(name);
-    if(range.first == range.second)
-        return defaultValue;
-
-    auto it = range.second;
-    it--;
-    return parseInt(it->second);
-}
-
-long Parameters::getLastLong(const std::string &name) const {
-    auto range = equal_range(name);
-    if(range.first == range.second)
-        throw ArgumentException(concat("No parameter found for key ", name));
-
-    auto it = range.second;
-    it--;
-    return parseLong(it->second);
-}
-
-long Parameters::getLastLong(const std::string &name, long defaultValue) const {
-    auto range = equal_range(name);
-    if(range.first == range.second)
-        return defaultValue;
-
-    auto it = range.second;
-    it--;
-    return parseLong(it->second);
-}
-
-bool Parameters::getLastBool(const std::string &name) const {
-    auto range = equal_range(name);
-    if(range.first == range.second)
-        throw ArgumentException(concat("No parameter found for key ", name));
-
-    auto it = range.second;
-    it--;
-    return parseBool(it->second);
-}
-
-bool Parameters::getLastBool(const std::string &name, bool defaultValue) const {
-    auto range = equal_range(name);
-    if(range.first == range.second)
-        return defaultValue;
-
-    auto it = range.second;
-    it--;
-    return parseBool(it->second);
-}
-
 
 int Parameters::parseInt(const std::string &str) {
     return std::stoi(str); // stoi throws if no conversion could be performed

--- a/src/util/parameters.cpp
+++ b/src/util/parameters.cpp
@@ -71,7 +71,8 @@ Parameters Parameters::getPrefixedParameters(const std::string &prefix) {
     for (auto &it : *this) {
         auto &key = it.first;
         if (key.length() > prefix.length() && key.substr(0, prefix.length()) == prefix) {
-            result[ key.substr(prefix.length()) ] = it.second;
+            result.insert(std::make_pair(key.substr(prefix.length()), it.second));
+            //result[ key.substr(prefix.length()) ] = it.second;
         }
     }
     return result;

--- a/src/util/parameters.h
+++ b/src/util/parameters.h
@@ -9,6 +9,7 @@ class Parameters : public std::multimap<std::string, std::string> {
 public:
     bool hasParam(const std::string& key) const;
 
+    //the getX functions return the last parameter of with that name inserted.
     const std::string &get(const std::string &name) const;
     const std::string &get(const std::string &name, const std::string &defaultValue) const;
     int getInt(const std::string &name) const;
@@ -17,16 +18,6 @@ public:
     long getLong(const std::string &name, long defaultValue) const;
     bool getBool(const std::string &name) const;
     bool getBool(const std::string &name, bool defaultValue) const;
-
-    const std::string &getLast(const std::string &name) const;
-    const std::string &getLast(const std::string &name, const std::string &defaultValue) const;
-    int getLastInt(const std::string &name) const;
-    int getLastInt(const std::string &name, int defaultValue) const;
-    long getLastLong(const std::string &name) const;
-    long getLastLong(const std::string &name, long defaultValue) const;
-    bool getLastBool(const std::string &name) const;
-    bool getLastBool(const std::string &name, bool defaultValue) const;
-
 
     std::vector<std::string> getAll(const std::string &name) const;
     std::vector<int> getAllInt(const std::string &name) const;

--- a/src/util/parameters.h
+++ b/src/util/parameters.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <map>
+#include <vector>
 
 class Parameters : public std::multimap<std::string, std::string> {
 public:
@@ -16,6 +17,22 @@ public:
     long getLong(const std::string &name, long defaultValue) const;
     bool getBool(const std::string &name) const;
     bool getBool(const std::string &name, bool defaultValue) const;
+
+    const std::string &getLast(const std::string &name) const;
+    const std::string &getLast(const std::string &name, const std::string &defaultValue) const;
+    int getLastInt(const std::string &name) const;
+    int getLastInt(const std::string &name, int defaultValue) const;
+    long getLastLong(const std::string &name) const;
+    long getLastLong(const std::string &name, long defaultValue) const;
+    bool getLastBool(const std::string &name) const;
+    bool getLastBool(const std::string &name, bool defaultValue) const;
+
+
+    std::vector<std::string> getAll(const std::string &name) const;
+    std::vector<int> getAllInt(const std::string &name) const;
+    std::vector<long> getAllLong(const std::string &name) const;
+    std::vector<bool> getAllBool(const std::string &name) const;
+
 
     /**
      * Returns all parameters with a given prefix, with the prefix stripped.

--- a/src/util/parameters.h
+++ b/src/util/parameters.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <map>
 
-class Parameters : public std::map<std::string, std::string> {
+class Parameters : public std::multimap<std::string, std::string> {
 public:
     bool hasParam(const std::string& key) const;
 

--- a/test/unittests/httpparsing.cpp
+++ b/test/unittests/httpparsing.cpp
@@ -64,6 +64,15 @@ TEST(HTTPParsing, getnovalue) {
 	EXPECT_EQ(params.get("value2", ""), "4");
 }
 
+// + and %20 should be decoded to spaces.
+TEST(HTTPParsing, spaces){
+    Parameters params;
+    parseCGIEnvironment(params, "GET", "/cgi-bin/bla",
+            "value=what+the%20spaces?");
+    EXPECT_EQ(params.get("value", ""), "what the spaces?");
+}
+
+
 // Test an empty query string
 TEST(HTTPParsing, emptyget) {
 	Parameters params;
@@ -162,90 +171,8 @@ const std::string multipart_message4 =
             "\r\n"
 		;
 
-
+// Parsing multipart data is not supported right now, so ArgumentException is expected.
 TEST(HTTPParsing, multipart) {
-	// Can not read multipart like this anymore, so ArgumentException is expected.
 	Parameters params;
 	EXPECT_THROW(parseCGIEnvironment(params, "POST", "/cgi-bin/bla", "","multipart/mixed; boundary=frontier", multipart_message), ArgumentException);
 }
-/*
-TEST(HTTPParsing, multipart_escaped_boundary) {
-	// This test should read the params "file1" and "file2".
-	Parameters params;
-	parseCGIEnvironment(params, "POST", "/cgi-bin/bla", "","multipart/form-data; boundary=--myboundary                ", multipart_message2);
-
-	EXPECT_TRUE(params.hasParam("file1"));
-    EXPECT_EQ(params["file1"], "Content of a.txt.");
-	EXPECT_TRUE(params.hasParam("file2"));
-    EXPECT_EQ(params["file2"], "");
-}
-
-TEST(HTTPParsing, multipart_unnamed_formdata) {
-	// This test should fail because the message contains form-data without a valid name.
-	// Expected: Throw ArgumentException "
-	Parameters params;
-	EXPECT_THROW(parseCGIEnvironment(params, "POST", "/cgi-bin/bla", "","multipart/form-data; boundary=xyz", multipart_message3),
-			ArgumentException);
-}
-
-TEST(HTTPParsing, multipart_malformed_boundary) {
-	// This test should fail because the message is malformed (missing the closing tag of the boundary).
-	// Expected: Throw runtime_error "Unexpected end of stream".
-	Parameters params;
-	EXPECT_THROW(parseCGIEnvironment(params, "POST", "/cgi-bin/bla", "","multipart/form-data; boundary=xyz", multipart_message4),
-			std::runtime_error);
-
-}
-
-TEST(HTTPParsing, multipart_missing_boundary) {
-	// This test should fail because the message is missing the specified boundary label.
-	// Expected: Throw runtime_error "Unexpected end of stream".
-	Parameters params;
-	EXPECT_THROW(parseCGIEnvironment(params, "POST", "/cgi-bin/bla", "","multipart/form-data; boundary=xyz", ""),
-			std::runtime_error);
-}
-
-TEST(HTTPParsing, multipart_unspecified_boundary) {
-	// This test should succeed. No parameters should be read, because no boundary has been specified.
-	Parameters params;
-	parseCGIEnvironment(params, "POST", "/cgi-bin/bla", "","multipart/mixed", multipart_message);
-	EXPECT_TRUE(params.empty());
-}
-
-TEST(HTTPParsing, parse_illegal_content_type) {
-	// This test should fail due to the unknown content-type.
-	// Expected: Throw ArgumentException "Unknown content type in POST request".
-	Parameters params;
-	EXPECT_THROW(parseCGIEnvironment(params, "POST", "/cgi-bin/bla", "","you-dont/know-me", multipart_message),
-			ArgumentException);
-
-}
-
-TEST(HTTPParsing, case_insensitive_request_method_post) {
-	// The test is exactly the same as the multipart_escaped_boundary test, the only difference being the character case in the REQUEST_METHOD parameter.
-	// This should NOT fail as per design, but shouldn't parse any parameters as well.
-	Parameters params;
-	parseCGIEnvironment(params, "PoST", "/cgi-bin/bla", "","multipart/form-data; boundary=--myboundary", multipart_message2);
-	EXPECT_TRUE(params.empty());
-
-}
-
-TEST(HTTPParsing, case_insensitive_request_method_get) {
-	// The same test using GET. This time get parameters should exist.
-	Parameters params;
-	parseCGIEnvironment(params, "PoST", "/cgi-bin/bla", "a=1&b=2&c=3","multipart/form-data; boundary=--myboundary", multipart_message2);
-	EXPECT_EQ(3, params.size());
-	EXPECT_EQ(1, params.getInt("a"));
-	EXPECT_EQ(2, params.getInt("b"));
-	EXPECT_EQ(3, params.getInt("c"));
-}
-
-TEST(HTTPParsing, EncodedAmpersandInValue) {
-	// Value of a parameter contains an encoded &
-	Parameters params;
-	parseCGIEnvironment(params, "GET", "/cgi-bin/bla", "foo=a%26b");
-
-	EXPECT_EQ(params.get("foo", "-"), "a&b");
-}
-*/
-

--- a/test/unittests/httpparsing.cpp
+++ b/test/unittests/httpparsing.cpp
@@ -115,23 +115,23 @@ TEST(HTTPParsing, illegalpercentencoding) {
 // This is a multipart message that with content-disposition NOT set as "form-data". Thus, no parameter is parsed here and the body is ignored as always.
 const std::string multipart_message =
 					"\r\n"
-					"This is a message with multiple parts in MIME format.\r\n"
 					"--frontier\r\n"
 					"Content-Type: text/plain\r\n"
 					"\r\n"
 					"This is the body of the message.\r\n"
+                    "\r\n"
 					"--frontier\r\n"
 					"Content-Type: application/octet-stream\r\n"
 					"Content-Transfer-Encoding: base64\r\n"
 					"\r\n"
 					"PGh0bWw+CiAgPGhlYWQ+CiAgPC9oZWFkPgogIDxib2R5PgogICAgPHA+VGhpcyBpcyB0aGUg\r\n"
 					"Ym9keSBvZiB0aGUgbWVzc2FnZS48L3A+CiAgPC9ib2R5Pgo8L2h0bWw+Cg==\r\n"
-					"--frontier--"
+					"\r\n"
+                    "--frontier--"
 					"--frontier--\r\n";
 
 // This is a multipart message that with content-disposition set as "form-data". A 'name' key is provided.
 const std::string multipart_message2 =
-		"Content-Length: 554\r\n" // Since it may provoke overflow attacks, content-length is ignored.
 		"\r\n"
 		"----myboundary\r\n"
 		"Content-Disposition: form-data; name=\"text\"\r\n"
@@ -142,26 +142,31 @@ const std::string multipart_message2 =
 		"Content-Type: text/plain\r\n"
 		"\r\n"
 		"Content of a.txt.\r\n"
-		"\r\n"
+        "\r\n"
 		"----myboundary\r\n"
 		"Content-Disposition: form-data; name=\"file2\"; filename=\"a.html\"\r\n"
 		"Content-Type: text/html\r\n"
+		"\n\n"
 		"----myboundary--"
 		;
 
 // This is a multipart message that with content-disposition set as "form-data". A 'name' key is NOT provided (which is not allowed).
 const std::string multipart_message3 =
 		"--xyz\r\n"
+                "\r\n"
 		"Content-Disposition: form-data;\r\n"
 		"xyz content\r\n"
+                "\r\n"
 		"--xyz--\r\n"
 		;
 
 // This is a multipart message with a corrupt boundary
 const std::string multipart_message4 =
 		"--xyz\r\n"
+                "\r\n"
 		"Content-Disposition: form-data;\r\n"
 		"xyz content\r\n"
+            "\r\n"
 		;
 
 
@@ -171,14 +176,16 @@ TEST(HTTPParsing, multipart) {
 	parseCGIEnvironment(params, "POST", "/cgi-bin/bla", "","multipart/mixed; boundary=frontier", multipart_message);
 	EXPECT_TRUE(params.empty());
 }
-
+/*
 TEST(HTTPParsing, multipart_escaped_boundary) {
 	// This test should read the params "file1" and "file2".
 	Parameters params;
 	parseCGIEnvironment(params, "POST", "/cgi-bin/bla", "","multipart/form-data; boundary=--myboundary                ", multipart_message2);
 
 	EXPECT_TRUE(params.hasParam("file1"));
+    EXPECT_EQ(params["file1"], "Content of a.txt.");
 	EXPECT_TRUE(params.hasParam("file2"));
+    EXPECT_EQ(params["file2"], "");
 }
 
 TEST(HTTPParsing, multipart_unnamed_formdata) {
@@ -248,5 +255,5 @@ TEST(HTTPParsing, EncodedAmpersandInValue) {
 
 	EXPECT_EQ(params.get("foo", "-"), "a&b");
 }
-
+*/
 

--- a/test/unittests/parameters.cpp
+++ b/test/unittests/parameters.cpp
@@ -4,11 +4,11 @@
 
 TEST(Parameters, getInt) {
 	Parameters params;
-	params["42"] = "42";
+	params.insert(std::make_pair("42", "42"));
 	// TODO: these three tests tell us the behaviour of stoi(). Not sure if that's the behaviour we want.
-	params["43"] = " 43";
-	params["44"] = "44 ";
-	params["45"] = "45b";
+	params.insert(std::make_pair("43", " 43"));
+	params.insert(std::make_pair("44", "44 "));
+	params.insert(std::make_pair("45", "45b"));
 
 	EXPECT_EQ(params.getInt("42"), 42);
 	EXPECT_EQ(params.getInt("43"), 43);
@@ -18,12 +18,12 @@ TEST(Parameters, getInt) {
 
 TEST(Parameters, getBool) {
 	Parameters params;
-	params["yes"] = "yEs";
-	params["true"] = "trUe";
-	params["1"] = "1";
-	params["no"] = "No";
-	params["false"] = "faLSe";
-	params["0"] = "0";
+	params.insert(std::make_pair("yes", "yEs"));
+	params.insert(std::make_pair("true", "trUe"));
+	params.insert(std::make_pair("1", "1"));
+	params.insert(std::make_pair("no", "No"));
+	params.insert(std::make_pair("false", "faLSe"));
+	params.insert(std::make_pair("0", "0"));
 
 	EXPECT_EQ(params.getBool("yes"), true);
 	EXPECT_EQ(params.getBool("true"), true);
@@ -35,15 +35,15 @@ TEST(Parameters, getBool) {
 
 TEST(Parameters, getPrefixedParameters) {
 	Parameters params;
-	params["test.a"] = "a";
-	params["test.b"] = "b";
-	params["test.c"] = "c";
-	params["test."] = "should be ignored";
-	params["other.a"] = "o.a";
-	params["other.b"] = "o.b";
-	params["other.c"] = "o.c";
-	params["other.d"] = "o.d";
-	params["a"] = "not a";
+	params.insert(std::make_pair("test.a", "a"));
+	params.insert(std::make_pair("test.b", "b"));
+	params.insert(std::make_pair("test.c", "c"));
+	params.insert(std::make_pair("test.", "should be ignored"));
+	params.insert(std::make_pair("other.a", "o.a"));
+	params.insert(std::make_pair("other.b", "o.b"));
+	params.insert(std::make_pair("other.c", "o.c"));
+	params.insert(std::make_pair("other.d", "o.d"));
+	params.insert(std::make_pair("a", "not a"));
 
 	auto prefixed = params.getPrefixedParameters("test.");
 	EXPECT_EQ(prefixed.size(), 3);


### PR DESCRIPTION
[Task 24:](https://dbs-projects.mathematik.uni-marburg.de/T24)
Replaced old HTTP parsing with Poco library. As discussed, multipart parsing support was dropped, but a MutlipartReader from Poco can be requested for manual parsing.
Parameters is now a multimap because query strings can have duplicate keys. Therefore getLast and getAll methods are supplied for all supported datatypes. The get methods will return the first element. C++ 11 guaranties that the insertion order of elements with the same key is preserved when iterating the map.
I am currently trying to test the linked linked crash of [T484](https://dbs-projects.mathematik.uni-marburg.de/T484).