### PR TITLE
Configuration Array Support

### DIFF
--- a/src/util/configuration.cpp
+++ b/src/util/configuration.cpp
@@ -15,7 +15,7 @@ std::vector<int> ConfigurationTable::getVector<int>(const std::string &name){
     auto int64_vector = table->get_qualified_array_of<int64_t>(name);
 
     if(!int64_vector)
-        throw ArgumentException("");
+        throw ArgumentException("Configuration: \'" + name + "\' not found as array.");
 
     std::vector<int> int_vector;
 

--- a/src/util/configuration.cpp
+++ b/src/util/configuration.cpp
@@ -9,6 +9,24 @@
 
 extern char **environ;
 
+//specialization to allow usage with type int. will create a copy of original vector.
+template<>
+std::vector<int> ConfigurationTable::getVector<int>(const std::string &name){
+    auto int64_vector = table->get_qualified_array_of<int64_t>(name);
+
+    if(!int64_vector)
+        throw ArgumentException("");
+
+    std::vector<int> int_vector;
+
+
+    for(auto &i : *int64_vector){
+        int_vector.push_back((int)i);
+    }
+
+    return int_vector;
+}
+
 /*
  * Configuration
  */

--- a/src/util/configuration.h
+++ b/src/util/configuration.h
@@ -63,6 +63,11 @@ class ConfigurationTable {
 
 };
 
+//specialization to allow usage with type int, because cpptoml only allows int64_t as a type. will create a copy of original vector.
+template<>
+std::vector<int> ConfigurationTable::getVector<int>(const std::string &name);
+
+
 /**
  * Class for loading the configuration of the application.
  * It loads key, value parameters from the following location in the given order

--- a/src/util/configuration.h
+++ b/src/util/configuration.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <map>
+#include <vector>
 #include "cpptoml.h"
 #include "util/exceptions.h"
 
@@ -11,6 +12,8 @@
  * and the subtables with:
  * 		ConfigurationTable subtable = Configuration::getSubTable(...);
  * 		subtable.get<T>(...)
+ *
+ *
  *
  * If more functionality is needed getTomlTable will give access to the underlying cpptoml::table.
  *
@@ -31,6 +34,16 @@ class ConfigurationTable {
         template <class T>
         T get(const std::string& name, const T& alternative){
             return table->get_qualified_as<T>(name).value_or(alternative);
+        }
+
+        /// \tparam T use int64_t instead of int
+        template <class T>
+        std::vector<T> getVector(const std::string &name) {
+            auto array_option = table->get_qualified_array_of<T>(name);
+            if(array_option)
+                return *array_option;
+            else
+                throw ArgumentException("Configuration: \'" + name + "\' not found as array.");
         }
 
         ConfigurationTable getSubTable(const std::string& name){
@@ -77,6 +90,11 @@ class Configuration {
         template <class T>
         static T get(const std::string& name, T alternative){
             return table.get<T>(name, alternative);
+        }
+
+        template <class T>
+        static std::vector<T> getVector(const std::string &name){
+            return table.getVector<T>(name);
         }
 
         static ConfigurationTable getSubTable(const std::string& name){

--- a/test/unittests/util/configuration.cpp
+++ b/test/unittests/util/configuration.cpp
@@ -1,6 +1,27 @@
+
 #include <gtest/gtest.h>
 #include "util/configuration.h"
 
+TEST(Configuration, arrays){
+    Configuration::loadFromString("doubleArray=[1.0,2.3,5.7]\n[sub]\nintArray=[1,2,3,10,20]\nboolarray=[false, true, false]");
+
+    std::vector<double> third = Configuration::getVector<double>("doubleArray");
+    EXPECT_EQ(third.size(), 3);
+    EXPECT_EQ(third[0], 1.0);
+    EXPECT_EQ(third[2], 5.7);
+
+    std::vector<int64_t> first = Configuration::getVector<int64_t>("sub.intArray");
+    EXPECT_EQ(first.size(), 5);
+    EXPECT_EQ(first[0], 1);
+    EXPECT_EQ(first[4], 20);
+
+    std::vector<bool> second = Configuration::getVector<bool>("sub.boolarray");
+    EXPECT_EQ(second.size(), 3);
+    EXPECT_EQ(second[0], false);
+    EXPECT_EQ(second[1], true);
+
+
+}
 
 TEST(Configuration, mergeTest){
 

--- a/test/unittests/util/configuration.cpp
+++ b/test/unittests/util/configuration.cpp
@@ -3,14 +3,14 @@
 #include "util/configuration.h"
 
 TEST(Configuration, arrays){
-    Configuration::loadFromString("doubleArray=[1.0,2.3,5.7]\n[sub]\nintArray=[1,2,3,10,20]\nboolarray=[false, true, false]");
+    Configuration::loadFromString("doubleArray=[1.0,2.3,5.7]\n[sub]\nintArray=[1,2,3,10,20]\nboolarray=[false, true, false]\nstringarray=[\"first\",\"scnd\"]");
 
     std::vector<double> third = Configuration::getVector<double>("doubleArray");
     EXPECT_EQ(third.size(), 3);
     EXPECT_EQ(third[0], 1.0);
     EXPECT_EQ(third[2], 5.7);
 
-    std::vector<int64_t> first = Configuration::getVector<int64_t>("sub.intArray");
+    std::vector<int> first = Configuration::getVector<int>("sub.intArray");
     EXPECT_EQ(first.size(), 5);
     EXPECT_EQ(first[0], 1);
     EXPECT_EQ(first[4], 20);
@@ -20,6 +20,11 @@ TEST(Configuration, arrays){
     EXPECT_EQ(second[0], false);
     EXPECT_EQ(second[1], true);
 
+    std::vector<std::string> fourth = Configuration::getVector<std::string>("sub.stringarray");
+
+    EXPECT_EQ(fourth.size(), 2);
+    EXPECT_EQ(fourth[0], "first");
+    EXPECT_EQ(fourth[1], "scnd");
 
 }
 


### PR DESCRIPTION
[T587](https://dbs-projects.mathematik.uni-marburg.de/T587) adding TOML array support. The method is called `getVector` (cpptoml returns a vector). 
Internally cpptoml only supports `int64_t` but not `int` as a type, so that the cpptoml call`get_array_of<int>` is not compiling. Therefore I wrote a template specialization, so that `getVector<int>` can be used. It creates a new vector and casts the elements one by one. If you prefer not having the specialization I will remove it and `Configuration::getVector<int64_t>` would have to be used.