### PR TITLE
Remove not needed data from ogr dataset listing

### DIFF
--- a/src/services/user.cpp
+++ b/src/services/user.cpp
@@ -88,7 +88,6 @@ void UserService::run() {
 			for(const auto &name : ogr_source_names){
 				if(user.hasPermission("data.ogr_source." + name)){
                     Json::Value description = OGRSourceDatasets::getDatasetListing(name);
-					description["name"] = name;
                     description["operator"] = "ogr_source";
 
 					// TODO: resolve name clashes

--- a/src/util/ogr_source_datasets.cpp
+++ b/src/util/ogr_source_datasets.cpp
@@ -37,16 +37,16 @@ std::vector<std::string> OGRSourceDatasets::getDatasetNames(){
 }
 
 Json::Value OGRSourceDatasets::getDatasetListing(const std::string &dataset_name){
-    Json::Value root = getDatasetDescription(dataset_name);
+    Json::Value desc = getDatasetDescription(dataset_name);
+    Json::Value root;
+    Json::Value columns = desc["columns"];
 
-    Json::Value columns = root["columns"];
-
-    bool isCsv = OGRSourceUtil::hasSuffix(root["filename"].asString(), ".csv") || OGRSourceUtil::hasSuffix(root["filename"].asString(), ".tsv");
+    bool isCsv = OGRSourceUtil::hasSuffix(desc["filename"].asString(), ".csv") || OGRSourceUtil::hasSuffix(desc["filename"].asString(), ".tsv");
 
     Json::Value layer_array(Json::ValueType::arrayValue);
 
     GDALAllRegister();
-    GDALDataset *dataset = OGRSourceUtil::openGDALDataset(root);
+    GDALDataset *dataset = OGRSourceUtil::openGDALDataset(desc);
 
     if(dataset == nullptr){
         throw OperatorException("OGR Source Datasets: Can not load dataset");

--- a/src/util/ogr_source_datasets.h
+++ b/src/util/ogr_source_datasets.h
@@ -17,17 +17,18 @@ public:
     static std::vector<std::string> getDatasetNames();
 
     /**
-     * Opens the datasets json file and returns json content. This content are basic query parameters.
-     * @param name of the dataset
-     * @return json defining the OGR dataset
+     * Opens the datasets json file and returns its content as a json object. The content is the basic query
+     * parameters for opening the corresponding vector file with the OGR Source Operator.
+     * @param name: name of the dataset to open.
+     * @return json object defining the OGR dataset
      */
     static Json::Value getDatasetDescription(const std::string &name);
 
     /**
-     * Open the description for the dataset and append that json by the available layers in
-     * the vector file on disk. Therefore the vector file is opened. Additionally for every layer the
-     * numeric and textual attribtues of that layer are provided.
-     * @param dataset_name
+     * Returns a json object containing all the available layers in the vector file on disk.
+     * Therefore the vector file is opened with OGR. Additionally for every layer the numeric
+     * and textual attributes of that layer are provided.
+     * @param dataset_name: name of the dataset to open.
      * @return dataset description json appended by information about available layers.
      */
     static Json::Value getDatasetListing(const std::string &dataset_name);


### PR DESCRIPTION
[T602](https://dbs-projects.mathematik.uni-marburg.de/T602): Cleaned up the ogr dataset listing so it only contains data the front end needs for a query: dataset name, layer names and attributes of the layers. A listing now looks like this:
```
"ogr_source_dataset1" : 
	{
		"layer" : 
		[
			{
				"name" : "osm_large_cities",
				"numeric" : 
				[
					"osm_id",
					"population"
				],
				"textual" : 
				[
					"name",
					"is_in"
				]
			}
		]
	}
```
Additionally I cleaned up the comments for the `OGRSourceDataset` class.