### PR TITLE
Exception Handling

### DIFF
--- a/src/cache/manager.cpp
+++ b/src/cache/manager.cpp
@@ -126,7 +126,7 @@ std::unique_ptr<T> ClientCacheWrapper<T>::query(
 		idx_resp = idx_con->write_and_read(ClientConnection::CMD_GET, req);
 	} catch ( const NetworkException &ne ) {
 		Log::error("Could not talk to index-server (%s:%d): %s", idx_host.c_str(), idx_port, ne.what());
-		throw OperatorException(ne.what());
+		std::throw_with_nested(OperatorException("", MappingExceptionType::SAME_AS_NESTED));
 	}
 
 	uint8_t idx_rc = idx_resp->read<uint8_t>();
@@ -157,7 +157,7 @@ std::unique_ptr<T> ClientCacheWrapper<T>::query(
 				}
 			} catch ( const NetworkException &ne ) {
 					Log::error("Could not retrieve result from delivery: %s", dr.to_string().c_str());
-					throw OperatorException(ne.what());
+					std::throw_with_nested(OperatorException("", MappingExceptionType::SAME_AS_NESTED));
 			}
 			break;
 		}

--- a/src/cache/manager.cpp
+++ b/src/cache/manager.cpp
@@ -126,7 +126,7 @@ std::unique_ptr<T> ClientCacheWrapper<T>::query(
 		idx_resp = idx_con->write_and_read(ClientConnection::CMD_GET, req);
 	} catch ( const NetworkException &ne ) {
 		Log::error("Could not talk to index-server (%s:%d): %s", idx_host.c_str(), idx_port, ne.what());
-		std::throw_with_nested(OperatorException("", MappingExceptionType::SAME_AS_NESTED));
+		std::throw_with_nested(OperatorException());
 	}
 
 	uint8_t idx_rc = idx_resp->read<uint8_t>();
@@ -157,7 +157,7 @@ std::unique_ptr<T> ClientCacheWrapper<T>::query(
 				}
 			} catch ( const NetworkException &ne ) {
 					Log::error("Could not retrieve result from delivery: %s", dr.to_string().c_str());
-					std::throw_with_nested(OperatorException("", MappingExceptionType::SAME_AS_NESTED));
+					std::throw_with_nested(OperatorException());
 			}
 			break;
 		}

--- a/src/cache/node/nodeserver.cpp
+++ b/src/cache/node/nodeserver.cpp
@@ -60,7 +60,7 @@ void NodeServer::worker_loop() {
 					Log::info("Read on worker-connection interrupted. Trying again.");
 				} catch (const NetworkException &ne) {
 					// Re-throw network-error to outer catch.
-					throw;
+				throw;
 				} catch (const std::exception &e) {
 					Log::error("Unexpected error while processing request: %s", e.what());
 					auto msg = concat("Unexpected error while processing request: ", e.what());

--- a/src/datatypes/raster/raster.cpp
+++ b/src/datatypes/raster/raster.cpp
@@ -362,7 +362,7 @@ void Raster<T, dimensions>::setRepresentation(Representation r) {
 		catch (cl::Error &e) {
 			std::stringstream ss;
 			ss << "CL Error in Raster::setRepresentation(): " << e.err() << ": " << e.what();
-			throw OpenCLException(ss.str());
+			throw OpenCLException(ss.str(), MappingExceptionType::PERMANENT);
 		}
 
 		clbuffer_info = RasterOpenCL::getBufferWithRasterinfo(this).release();

--- a/src/datatypes/raster/raster.cpp
+++ b/src/datatypes/raster/raster.cpp
@@ -362,7 +362,7 @@ void Raster<T, dimensions>::setRepresentation(Representation r) {
 		catch (cl::Error &e) {
 			std::stringstream ss;
 			ss << "CL Error in Raster::setRepresentation(): " << e.err() << ": " << e.what();
-			throw OpenCLException(ss.str(), MappingExceptionType::PERMANENT);
+			throw OpenCLException(ss.str(), MappingExceptionType::CONFIDENTIAL);
 		}
 
 		clbuffer_info = RasterOpenCL::getBufferWithRasterinfo(this).release();

--- a/src/featurecollectiondb/featurecollectiondb.cpp
+++ b/src/featurecollectiondb/featurecollectiondb.cpp
@@ -48,7 +48,7 @@ void FeatureCollectionDB::init(const std::string &backend, const std::string &lo
 
 	auto map = getRegisteredConstructorsMap();
 	if (map->count(backend) != 1)
-		throw ArgumentException(concat("Unknown featurecollectiondb backend: ", backend));
+		throw ArgumentException(concat("Unknown featurecollectiondb backend: ", backend), MappingExceptionType::TRANSIENT);
 
 
 	auto constructor = map->at(backend);

--- a/src/featurecollectiondb/featurecollectiondbbackend_postgres.cpp
+++ b/src/featurecollectiondb/featurecollectiondbbackend_postgres.cpp
@@ -118,7 +118,7 @@ FeatureCollectionDBBackend::DataSetMetaData PostgresFeatureCollectionDBBackend::
 	} else if(type == "polygons") {
 		resultType = Query::ResultType::POLYGONS;
 	} else {
-		throw MustNotHappenException("Invalid type of feature collection");
+		throw MustNotHappenException("Invalid type of feature collection", MappingExceptionType::TRANSIENT);
 	}
 
 	Json::Value json;
@@ -211,7 +211,7 @@ FeatureCollectionDBBackend::datasetid_t PostgresFeatureCollectionDBBackend::crea
 	} else if(type == Query::ResultType::POLYGONS) {
 		typeString = "polygons";
 	} else {
-		throw ArgumentException("PostgresFeatureCollectionDBBacken: unknown result type");
+		throw ArgumentException("PostgresFeatureCollectionDBBackend: unknown result type", MappingExceptionType::PERMANENT);
 	}
 
 	pqxx::result result = work.prepared("insert_dataset")(user.userid)(dataSetName)(typeString)(writer.write(numeric_attributes))(writer.write(textual_attributes))(collection.hasTime()).exec();
@@ -410,7 +410,7 @@ void PostgresFeatureCollectionDBBackend::loadFeatures(SimpleFeatureCollection &c
 		} else if (type == Query::ResultType::POLYGONS) {
 			WKBUtil::addFeatureToCollection(dynamic_cast<PolygonCollection&>(collection), row["geom"].as<std::string>());
 		} else {
-			throw ArgumentException("PostgresFeatureCollectionDBBackend: Invalid type of feature collection");
+			throw ArgumentException("PostgresFeatureCollectionDBBackend: Invalid type of feature collection", MappingExceptionType::PERMANENT);
 		}
 
 		// attributes

--- a/src/featurecollectiondb/featurecollectiondbbackend_postgres.cpp
+++ b/src/featurecollectiondb/featurecollectiondbbackend_postgres.cpp
@@ -118,7 +118,7 @@ FeatureCollectionDBBackend::DataSetMetaData PostgresFeatureCollectionDBBackend::
 	} else if(type == "polygons") {
 		resultType = Query::ResultType::POLYGONS;
 	} else {
-		throw MustNotHappenException("Invalid type of feature collection", MappingExceptionType::TRANSIENT);
+		throw MustNotHappenException("Invalid type of feature collection", MappingExceptionType::PERMANENT);
 	}
 
 	Json::Value json;

--- a/src/operators/processing/combined/raster_value_extraction.cpp
+++ b/src/operators/processing/combined/raster_value_extraction.cpp
@@ -140,8 +140,9 @@ static void enhance(PointCollection &points, GenericRaster &raster, const std::s
         prog.run();
     }
     catch (cl::Error &e) {
-        printf("cl::Error %d: %s\n", e.err(), e.what());
-        throw;
+        std::stringstream ss;
+        ss << "cl::Error " << e.err() << ": " << e.what();
+        throw OpenCLException(ss.str(), MappingExceptionType::CONFIDENTIAL);
     }
 #endif
 }

--- a/src/operators/processing/features/difference.cpp
+++ b/src/operators/processing/features/difference.cpp
@@ -103,8 +103,9 @@ std::unique_ptr<PointCollection> DifferenceOperator::getPointCollection(const Qu
 		prog.run();
 	}
 	catch (cl::Error &e) {
-		printf("cl::Error %d: %s\n", e.err(), e.what());
-		throw;
+		std::stringstream ss;
+		ss << "cl::Error " << e.err() << ": " << e.what();
+		throw OpenCLException(ss.str(), MappingExceptionType::CONFIDENTIAL);
 	}
 
 #endif

--- a/src/operators/processing/meteosat/msg_constants.h
+++ b/src/operators/processing/meteosat/msg_constants.h
@@ -81,7 +81,7 @@ namespace msg{
 			if (sat.name == satellite_name)
 				return sat;
 		}
-		throw ArgumentException(satellite_name + " is not a known METEOSAT Satellite name!");
+		throw ArgumentException(satellite_name + " is not a known METEOSAT Satellite name!", MappingExceptionType::TRANSIENT);
 	}
 
 	/**
@@ -94,7 +94,7 @@ namespace msg{
 					if (sat.msg_id == msg_id)
 						return sat;
 				}
-		throw ArgumentException(std::to_string(msg_id) + " is no id of a known METEOSAT Satellite!");
+		throw ArgumentException(std::to_string(msg_id) + " is no id of a known METEOSAT Satellite!", MappingExceptionType::TRANSIENT);
 	}
 
 

--- a/src/operators/processing/raster/matrixkernel.cpp
+++ b/src/operators/processing/raster/matrixkernel.cpp
@@ -134,8 +134,9 @@ std::unique_ptr<GenericRaster> MatrixOperator::getRaster(const QueryRectangle &r
 
 	}
 	catch (cl::Error &e) {
-		fprintf(stderr, "cl::Error %d: %s\n", e.err(), e.what());
-		throw;
+		std::stringstream ss;
+		ss << "cl::Error " << e.err() << ": " << e.what();
+		throw OpenCLException(ss.str(), MappingExceptionType::CONFIDENTIAL);
 	}
 
 	return raster_out;

--- a/src/operators/source/wkt_source.cpp
+++ b/src/operators/source/wkt_source.cpp
@@ -22,7 +22,7 @@ class WKTSourceOperator : public GenericOperator {
 			type = params.get("type", "").asString();
 
 			if(type != "points" && type != "lines" && type != "polygons")
-				throw ArgumentException("WKTSource: Invalid type given");
+				throw ArgumentException("WKTSource: Invalid type given", MappingExceptionType::PERMANENT);
 		}
 
 #ifndef MAPPING_OPERATOR_STUBS

--- a/src/processing/backend_local.cpp
+++ b/src/processing/backend_local.cpp
@@ -47,11 +47,14 @@ std::unique_ptr<QueryProcessor::QueryResult> LocalQueryProcessor::process(const 
 			return QueryProcessor::QueryResult::plot(plot->toJSON(), q.rectangle, std::move(provenance));
 		}
 		else {
-			throw ArgumentException("Unknown query type", MappingExceptionType::TRANSIENT);
+			throw ArgumentException("Unknown query type", MappingExceptionType::PERMANENT);
 		}
 	}
+	catch (MappingException &me){
+		return QueryProcessor::QueryResult::error(me.what(), q.rectangle, me.getExceptionType());
+	}
 	catch (const std::exception &e) {
-		return QueryProcessor::QueryResult::error(e.what(), q.rectangle);
+		return QueryProcessor::QueryResult::error(e.what(), q.rectangle, MappingExceptionType::CONFIDENTIAL);
 	}
 }
 

--- a/src/processing/backend_local.cpp
+++ b/src/processing/backend_local.cpp
@@ -47,7 +47,7 @@ std::unique_ptr<QueryProcessor::QueryResult> LocalQueryProcessor::process(const 
 			return QueryProcessor::QueryResult::plot(plot->toJSON(), q.rectangle, std::move(provenance));
 		}
 		else {
-			throw ArgumentException("Unknown query type");
+			throw ArgumentException("Unknown query type", MappingExceptionType::TRANSIENT);
 		}
 	}
 	catch (const std::exception &e) {

--- a/src/processing/backend_local.cpp
+++ b/src/processing/backend_local.cpp
@@ -51,10 +51,10 @@ std::unique_ptr<QueryProcessor::QueryResult> LocalQueryProcessor::process(const 
 		}
 	}
 	catch (MappingException &me){
-		return QueryProcessor::QueryResult::error(me.what(), q.rectangle, me.getExceptionType());
+		return QueryProcessor::QueryResult::error(me, q.rectangle);
 	}
 	catch (const std::exception &e) {
-		return QueryProcessor::QueryResult::error(e.what(), q.rectangle, MappingExceptionType::CONFIDENTIAL);
+		return QueryProcessor::QueryResult::error(MappingException(e.what(), MappingExceptionType::CONFIDENTIAL), q.rectangle);
 	}
 }
 

--- a/src/processing/queryprocessor.cpp
+++ b/src/processing/queryprocessor.cpp
@@ -40,8 +40,8 @@ QueryProcessor::~QueryProcessor() {
 /*
  * QueryResult
  */
-QueryProcessor::QueryResult::QueryResult(Query::ResultType result_type, std::unique_ptr<SpatioTemporalResult> result, std::unique_ptr<ProvenanceCollection> provenance, const std::string &result_plot, const std::string &result_error, const QueryRectangle &qrect)
-	: result_type(result_type), result(std::move(result)), provenance(std::move(provenance)), result_plot(result_plot), result_error(result_error), qrect(qrect) {
+QueryProcessor::QueryResult::QueryResult(Query::ResultType result_type, std::unique_ptr<SpatioTemporalResult> result, std::unique_ptr<ProvenanceCollection> provenance, const std::string &result_plot, const std::string &result_error, const QueryRectangle &qrect, const MappingExceptionType errorType)
+	: result_type(result_type), result(std::move(result)), provenance(std::move(provenance)), result_plot(result_plot), result_error(result_error), qrect(qrect), errorType(errorType) {
 }
 
 std::unique_ptr<QueryProcessor::QueryResult> QueryProcessor::QueryResult::raster(std::unique_ptr<GenericRaster> result, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance) {
@@ -59,8 +59,8 @@ std::unique_ptr<QueryProcessor::QueryResult> QueryProcessor::QueryResult::polygo
 std::unique_ptr<QueryProcessor::QueryResult> QueryProcessor::QueryResult::plot(const std::string &plot, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance) {
 	return std::unique_ptr<QueryResult>(new QueryResult(Query::ResultType::PLOT, nullptr, std::move(provenance), plot, "", qrect));
 }
-std::unique_ptr<QueryProcessor::QueryResult> QueryProcessor::QueryResult::error(const std::string &error, const QueryRectangle &qrect) {
-	return std::unique_ptr<QueryResult>(new QueryResult(Query::ResultType::ERROR, nullptr, nullptr, "", error, qrect));
+std::unique_ptr<QueryProcessor::QueryResult> QueryProcessor::QueryResult::error(const std::string &error, const QueryRectangle &qrect, MappingExceptionType errorType) {
+	return std::unique_ptr<QueryResult>(new QueryResult(Query::ResultType::ERROR, nullptr, nullptr, "", error, qrect, errorType));
 }
 
 
@@ -159,5 +159,9 @@ bool QueryProcessor::QueryResult::isError() {
 
 std::string QueryProcessor::QueryResult::getErrorMessage() {
 	return result_error;
+}
+
+MappingExceptionType QueryProcessor::QueryResult::getErrorType(){
+	return errorType;
 }
 

--- a/src/processing/queryprocessor.cpp
+++ b/src/processing/queryprocessor.cpp
@@ -40,27 +40,27 @@ QueryProcessor::~QueryProcessor() {
 /*
  * QueryResult
  */
-QueryProcessor::QueryResult::QueryResult(Query::ResultType result_type, std::unique_ptr<SpatioTemporalResult> result, std::unique_ptr<ProvenanceCollection> provenance, const std::string &result_plot, const std::string &result_error, const QueryRectangle &qrect, const MappingExceptionType errorType)
-	: result_type(result_type), result(std::move(result)), provenance(std::move(provenance)), result_plot(result_plot), result_error(result_error), qrect(qrect), errorType(errorType) {
+QueryProcessor::QueryResult::QueryResult(Query::ResultType result_type, std::unique_ptr<SpatioTemporalResult> result, std::unique_ptr<ProvenanceCollection> provenance, const std::string &result_plot, const MappingException &exception, const QueryRectangle &qrect)
+	: result_type(result_type), result(std::move(result)), provenance(std::move(provenance)), result_plot(result_plot), result_exception(exception), qrect(qrect) {
 }
 
 std::unique_ptr<QueryProcessor::QueryResult> QueryProcessor::QueryResult::raster(std::unique_ptr<GenericRaster> result, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance) {
-	return std::unique_ptr<QueryResult>(new QueryResult(Query::ResultType::RASTER, std::move(result), std::move(provenance), "", "", qrect));
+	return std::unique_ptr<QueryResult>(new QueryResult(Query::ResultType::RASTER, std::move(result), std::move(provenance), "", MappingException(), qrect));
 }
 std::unique_ptr<QueryProcessor::QueryResult> QueryProcessor::QueryResult::points(std::unique_ptr<PointCollection> result, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance) {
-	return std::unique_ptr<QueryResult>(new QueryResult(Query::ResultType::POINTS, std::move(result), std::move(provenance), "", "", qrect));
+	return std::unique_ptr<QueryResult>(new QueryResult(Query::ResultType::POINTS, std::move(result), std::move(provenance), "", MappingException(), qrect));
 }
 std::unique_ptr<QueryProcessor::QueryResult> QueryProcessor::QueryResult::lines(std::unique_ptr<LineCollection> result, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance) {
-	return std::unique_ptr<QueryResult>(new QueryResult(Query::ResultType::LINES, std::move(result), std::move(provenance), "", "", qrect));
+	return std::unique_ptr<QueryResult>(new QueryResult(Query::ResultType::LINES, std::move(result), std::move(provenance), "", MappingException(), qrect));
 }
 std::unique_ptr<QueryProcessor::QueryResult> QueryProcessor::QueryResult::polygons(std::unique_ptr<PolygonCollection> result, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance) {
-	return std::unique_ptr<QueryResult>(new QueryResult(Query::ResultType::POLYGONS, std::move(result), std::move(provenance), "", "", qrect));
+	return std::unique_ptr<QueryResult>(new QueryResult(Query::ResultType::POLYGONS, std::move(result), std::move(provenance), "", MappingException(), qrect));
 }
 std::unique_ptr<QueryProcessor::QueryResult> QueryProcessor::QueryResult::plot(const std::string &plot, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance) {
-	return std::unique_ptr<QueryResult>(new QueryResult(Query::ResultType::PLOT, nullptr, std::move(provenance), plot, "", qrect));
+	return std::unique_ptr<QueryResult>(new QueryResult(Query::ResultType::PLOT, nullptr, std::move(provenance), plot, MappingException(), qrect));
 }
-std::unique_ptr<QueryProcessor::QueryResult> QueryProcessor::QueryResult::error(const std::string &error, const QueryRectangle &qrect, MappingExceptionType errorType) {
-	return std::unique_ptr<QueryResult>(new QueryResult(Query::ResultType::ERROR, nullptr, nullptr, "", error, qrect, errorType));
+std::unique_ptr<QueryProcessor::QueryResult> QueryProcessor::QueryResult::error(const MappingException &exception, const QueryRectangle &qrect) {
+	return std::unique_ptr<QueryResult>(new QueryResult(Query::ResultType::ERROR, nullptr, nullptr, "", exception, qrect));
 }
 
 
@@ -79,9 +79,9 @@ std::unique_ptr<T> cast_unique_ptr(std::unique_ptr<SpatioTemporalResult> &src) {
 
 std::unique_ptr<GenericRaster> QueryProcessor::QueryResult::getRaster(GenericOperator::RasterQM query_mode) {
 	if (result_type == Query::ResultType::ERROR)
-		throw std::runtime_error(result_error);
+		throw result_exception;
 	if (result_type != Query::ResultType::RASTER)
-		throw std::runtime_error("QueryResult::getRaster(): result is not a raster");
+		throw ProcessingException("QueryResult::getRaster(): result is not a raster", MappingExceptionType::PERMANENT);
 
 	auto raster = cast_unique_ptr<GenericRaster>(result);
 	if (query_mode == GenericOperator::RasterQM::EXACT)
@@ -91,9 +91,9 @@ std::unique_ptr<GenericRaster> QueryProcessor::QueryResult::getRaster(GenericOpe
 
 std::unique_ptr<PointCollection> QueryProcessor::QueryResult::getPointCollection(GenericOperator::FeatureCollectionQM query_mode) {
 	if (result_type == Query::ResultType::ERROR)
-		throw std::runtime_error(result_error);
+		throw result_exception;
 	if (result_type != Query::ResultType::POINTS)
-		throw std::runtime_error("QueryResult::getPointCollection(): result is not a PointCollection");
+		throw ProcessingException("QueryResult::getPointCollection(): result is not a PointCollection", MappingExceptionType::PERMANENT);
 
 	auto points = cast_unique_ptr<PointCollection>(result);
 	if (query_mode == GenericOperator::FeatureCollectionQM::SINGLE_ELEMENT_FEATURES && !points->isSimple())
@@ -103,9 +103,9 @@ std::unique_ptr<PointCollection> QueryProcessor::QueryResult::getPointCollection
 
 std::unique_ptr<LineCollection> QueryProcessor::QueryResult::getLineCollection(GenericOperator::FeatureCollectionQM query_mode) {
 	if (result_type == Query::ResultType::ERROR)
-		throw std::runtime_error(result_error);
+		throw result_exception;
 	if (result_type != Query::ResultType::LINES)
-		throw std::runtime_error("QueryResult::getLineCollection(): result is not a LineCollection");
+		throw ProcessingException("QueryResult::getLineCollection(): result is not a LineCollection", MappingExceptionType::PERMANENT);
 
 	auto lines = cast_unique_ptr<LineCollection>(result);
 	if (query_mode == GenericOperator::FeatureCollectionQM::SINGLE_ELEMENT_FEATURES && !lines->isSimple())
@@ -115,9 +115,9 @@ std::unique_ptr<LineCollection> QueryProcessor::QueryResult::getLineCollection(G
 
 std::unique_ptr<PolygonCollection> QueryProcessor::QueryResult::getPolygonCollection(GenericOperator::FeatureCollectionQM query_mode) {
 	if (result_type == Query::ResultType::ERROR)
-		throw std::runtime_error(result_error);
+		throw result_exception;
 	if (result_type != Query::ResultType::POLYGONS)
-		throw std::runtime_error("QueryResult::getPolygonCollection(): result is not a PolygonCollection");
+		throw ProcessingException("QueryResult::getPolygonCollection(): result is not a PolygonCollection", MappingExceptionType::PERMANENT);
 
 	auto polygons = cast_unique_ptr<PolygonCollection>(result);
 	if (query_mode == GenericOperator::FeatureCollectionQM::SINGLE_ELEMENT_FEATURES && !polygons->isSimple())
@@ -127,9 +127,9 @@ std::unique_ptr<PolygonCollection> QueryProcessor::QueryResult::getPolygonCollec
 
 std::unique_ptr<SimpleFeatureCollection> QueryProcessor::QueryResult::getAnyFeatureCollection(GenericOperator::FeatureCollectionQM query_mode) {
 	if (result_type == Query::ResultType::ERROR)
-		throw std::runtime_error(result_error);
+		throw result_exception;
 	if (result_type != Query::ResultType::POINTS && result_type != Query::ResultType::LINES && result_type != Query::ResultType::POLYGONS)
-		throw std::runtime_error("QueryResult::getAnyFeatureCollection(): result is not a SimpleFeatureCollection");
+		throw ProcessingException("QueryResult::getAnyFeatureCollection(): result is not a SimpleFeatureCollection", MappingExceptionType::PERMANENT);
 
 	auto features = cast_unique_ptr<SimpleFeatureCollection>(result);
 	if (query_mode == GenericOperator::FeatureCollectionQM::SINGLE_ELEMENT_FEATURES && !features->isSimple())
@@ -139,16 +139,16 @@ std::unique_ptr<SimpleFeatureCollection> QueryProcessor::QueryResult::getAnyFeat
 
 std::string QueryProcessor::QueryResult::getPlot() {
 	if (result_type == Query::ResultType::ERROR)
-		throw std::runtime_error(result_error);
+		throw result_exception;
 	if (result_type != Query::ResultType::PLOT)
-		throw std::runtime_error("QueryResult::getPlot(): result is not a plot");
+		throw ProcessingException("QueryResult::getPlot(): result is not a plot", MappingExceptionType::PERMANENT);
 
 	return std::move(result_plot);
 }
 
 ProvenanceCollection& QueryProcessor::QueryResult::getProvenance() {
 	if (provenance.get() == nullptr) {
-		throw std::runtime_error("QueryProcessor: getProvenance not available");
+		throw ProcessingException("QueryProcessor: getProvenance not available", MappingExceptionType::PERMANENT);
 	}
 	return *provenance;
 }
@@ -157,11 +157,7 @@ bool QueryProcessor::QueryResult::isError() {
 	return result_type == Query::ResultType::ERROR;
 }
 
-std::string QueryProcessor::QueryResult::getErrorMessage() {
-	return result_error;
-}
-
-MappingExceptionType QueryProcessor::QueryResult::getErrorType(){
-	return errorType;
+MappingException QueryProcessor::QueryResult::getErrorException(){
+	return result_exception;
 }
 

--- a/src/processing/queryprocessor.h
+++ b/src/processing/queryprocessor.h
@@ -41,21 +41,23 @@ class QueryProcessor {
 				ProvenanceCollection& getProvenance();
 				bool isError();
 				std::string getErrorMessage();
+				MappingExceptionType getErrorType();
 
-				static std::unique_ptr<QueryResult> raster(std::unique_ptr<GenericRaster> result, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance);
+			static std::unique_ptr<QueryResult> raster(std::unique_ptr<GenericRaster> result, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance);
 				static std::unique_ptr<QueryResult> points(std::unique_ptr<PointCollection> result, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance);
 				static std::unique_ptr<QueryResult> lines(std::unique_ptr<LineCollection> result, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance);
 				static std::unique_ptr<QueryResult> polygons(std::unique_ptr<PolygonCollection> result, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance);
 				static std::unique_ptr<QueryResult> plot(const std::string &plot, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance);
-				static std::unique_ptr<QueryResult> error(const std::string &error, const QueryRectangle &qrect);
+				static std::unique_ptr<QueryResult> error(const std::string &error, const QueryRectangle &qrect, const MappingExceptionType errorType);
 			private:
-				QueryResult(Query::ResultType result_type, std::unique_ptr<SpatioTemporalResult> result, std::unique_ptr<ProvenanceCollection> provenance, const std::string &result_plot, const std::string &error, const QueryRectangle &qrect);
+				QueryResult(Query::ResultType result_type, std::unique_ptr<SpatioTemporalResult> result, std::unique_ptr<ProvenanceCollection> provenance, const std::string &result_plot, const std::string &error, const QueryRectangle &qrect, MappingExceptionType errorType = MappingExceptionType::CONFIDENTIAL);
 				Query::ResultType result_type;
 				std::unique_ptr<SpatioTemporalResult> result;
 				std::unique_ptr<ProvenanceCollection> provenance;
 				std::string result_plot;
 				std::string result_error;
 				QueryRectangle qrect;
+				MappingExceptionType errorType;
 		};
 
 		class QueryProgress {

--- a/src/processing/queryprocessor.h
+++ b/src/processing/queryprocessor.h
@@ -40,24 +40,22 @@ class QueryProcessor {
 				std::string getPlot();
 				ProvenanceCollection& getProvenance();
 				bool isError();
-				std::string getErrorMessage();
-				MappingExceptionType getErrorType();
+				MappingException getErrorException();
 
 			static std::unique_ptr<QueryResult> raster(std::unique_ptr<GenericRaster> result, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance);
 				static std::unique_ptr<QueryResult> points(std::unique_ptr<PointCollection> result, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance);
 				static std::unique_ptr<QueryResult> lines(std::unique_ptr<LineCollection> result, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance);
 				static std::unique_ptr<QueryResult> polygons(std::unique_ptr<PolygonCollection> result, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance);
 				static std::unique_ptr<QueryResult> plot(const std::string &plot, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance);
-				static std::unique_ptr<QueryResult> error(const std::string &error, const QueryRectangle &qrect, const MappingExceptionType errorType);
+				static std::unique_ptr<QueryResult> error(const MappingException &exception, const QueryRectangle &qrect);
 			private:
-				QueryResult(Query::ResultType result_type, std::unique_ptr<SpatioTemporalResult> result, std::unique_ptr<ProvenanceCollection> provenance, const std::string &result_plot, const std::string &error, const QueryRectangle &qrect, MappingExceptionType errorType = MappingExceptionType::CONFIDENTIAL);
+				QueryResult(Query::ResultType result_type, std::unique_ptr<SpatioTemporalResult> result, std::unique_ptr<ProvenanceCollection> provenance, const std::string &result_plot, const MappingException &exception, const QueryRectangle &qrect);
 				Query::ResultType result_type;
 				std::unique_ptr<SpatioTemporalResult> result;
 				std::unique_ptr<ProvenanceCollection> provenance;
 				std::string result_plot;
-				std::string result_error;
 				QueryRectangle qrect;
-				MappingExceptionType errorType;
+				MappingException result_exception;
 		};
 
 		class QueryProgress {

--- a/src/processing/queryprocessor.h
+++ b/src/processing/queryprocessor.h
@@ -5,6 +5,7 @@
 #include "operators/provenance.h"
 #include <memory>
 #include <util/configuration.h>
+#include <boost/optional.hpp>
 
 
 class GenericRaster;
@@ -40,7 +41,7 @@ class QueryProcessor {
 				std::string getPlot();
 				ProvenanceCollection& getProvenance();
 				bool isError();
-				MappingException getErrorException();
+				boost::optional<MappingException> getErrorException();
 
 			static std::unique_ptr<QueryResult> raster(std::unique_ptr<GenericRaster> result, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance);
 				static std::unique_ptr<QueryResult> points(std::unique_ptr<PointCollection> result, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance);
@@ -49,13 +50,13 @@ class QueryProcessor {
 				static std::unique_ptr<QueryResult> plot(const std::string &plot, const QueryRectangle &qrect, std::unique_ptr<ProvenanceCollection> provenance);
 				static std::unique_ptr<QueryResult> error(const MappingException &exception, const QueryRectangle &qrect);
 			private:
-				QueryResult(Query::ResultType result_type, std::unique_ptr<SpatioTemporalResult> result, std::unique_ptr<ProvenanceCollection> provenance, const std::string &result_plot, const MappingException &exception, const QueryRectangle &qrect);
+				QueryResult(Query::ResultType result_type, std::unique_ptr<SpatioTemporalResult> result, std::unique_ptr<ProvenanceCollection> provenance, const std::string &result_plot, boost::optional<MappingException> exception, const QueryRectangle &qrect);
 				Query::ResultType result_type;
 				std::unique_ptr<SpatioTemporalResult> result;
 				std::unique_ptr<ProvenanceCollection> provenance;
 				std::string result_plot;
 				QueryRectangle qrect;
-				MappingException result_exception;
+				boost::optional<MappingException> result_exception;
 		};
 
 		class QueryProgress {

--- a/src/processing/queryprocessor_backend.cpp
+++ b/src/processing/queryprocessor_backend.cpp
@@ -32,7 +32,7 @@ QueryProcessorBackendRegistration::QueryProcessorBackendRegistration(const char 
 std::unique_ptr<QueryProcessor> QueryProcessor::create(const std::string &backend, const ConfigurationTable& params) {
 	auto map = getRegisteredConstructorsMap();
 	if (map->count(backend) != 1)
-		throw ArgumentException(concat("Unknown QueryProcessor backend: ", backend));
+		throw ArgumentException(concat("Unknown QueryProcessor backend: ", backend), MappingExceptionType::PERMANENT);
 
 	auto constructor = map->at(backend);
 	auto backend_instance = constructor(params);

--- a/src/processing/queryprocessor_backend.cpp
+++ b/src/processing/queryprocessor_backend.cpp
@@ -32,7 +32,7 @@ QueryProcessorBackendRegistration::QueryProcessorBackendRegistration(const char 
 std::unique_ptr<QueryProcessor> QueryProcessor::create(const std::string &backend, const ConfigurationTable& params) {
 	auto map = getRegisteredConstructorsMap();
 	if (map->count(backend) != 1)
-		throw ArgumentException(concat("Unknown QueryProcessor backend: ", backend), MappingExceptionType::PERMANENT);
+		throw ArgumentException(concat("Unknown QueryProcessor backend: ", backend), MappingExceptionType::TRANSIENT);
 
 	auto constructor = map->at(backend);
 	auto backend_instance = constructor(params);

--- a/src/raster/opencl.cpp
+++ b/src/raster/opencl.cpp
@@ -269,7 +269,7 @@ cl::Program compileSource(const std::string &sourcecode) {
 	catch (const cl::Error &e) {
 		std::stringstream ss;
 		ss << "Error building cl::Program: " << e.what() << " " << program.getBuildInfo<CL_PROGRAM_BUILD_LOG>(deviceList[0]);
-		throw OpenCLException(ss.str());
+		throw OpenCLException(ss.str(), MappingExceptionType::CONFIDENTIAL);
 	}
 
 	program_cache[sourcecode] = program;

--- a/src/raster/opencl.cpp
+++ b/src/raster/opencl.cpp
@@ -85,9 +85,9 @@ void init() {
 				);
 			}
 			catch (const cl::Error &e) {
-				printf("Error %d: %s\n", e.err(), e.what());
-
-				throw;
+				std::stringstream ss;
+				ss << "Error " << e.err() << ": " << e.what();
+				throw OpenCLException(ss.str(), MappingExceptionType::CONFIDENTIAL);
 			}
 
 			// Device
@@ -230,7 +230,7 @@ std::unique_ptr<cl::Buffer> getBufferWithRasterinfo(GenericRaster *raster) {
 	catch (cl::Error &e) {
 		std::stringstream ss;
 		ss << "CL Error in getBufferWithRasterinfo(): " << e.err() << ": " << e.what();
-		throw OpenCLException(ss.str());
+		throw OpenCLException(ss.str(), MappingExceptionType::CONFIDENTIAL);
 	}
 }
 
@@ -267,7 +267,9 @@ cl::Program compileSource(const std::string &sourcecode) {
 		program.build(deviceList,""); // "-cl-std=CL2.0"
 	}
 	catch (const cl::Error &e) {
-		throw OpenCLException(concat("Error building cl::Program: ", e.what(), " ", program.getBuildInfo<CL_PROGRAM_BUILD_LOG>(deviceList[0])));
+		std::stringstream ss;
+		ss << "Error building cl::Program: " << e.what() << " " << program.getBuildInfo<CL_PROGRAM_BUILD_LOG>(deviceList[0]);
+		throw OpenCLException(ss.str());
 	}
 
 	program_cache[sourcecode] = program;
@@ -376,7 +378,7 @@ void CLProgram::compile(const std::string &sourcecode, const char *kernelname) {
 		kernel.reset(nullptr);
 		std::stringstream msg;
 		msg << "CL Error in compile(): " << e.err() << ": " << e.what();
-		throw OpenCLException(msg.str());
+		throw OpenCLException(msg.str(), MappingExceptionType::CONFIDENTIAL);
 	}
 
 }
@@ -397,7 +399,7 @@ void CLProgram::run() {
 	catch (cl::Error &e) {
 		std::stringstream ss;
 		ss << "CL Error: " << e.err() << ": " << e.what();
-		throw OpenCLException(ss.str());
+		throw OpenCLException(ss.str(), MappingExceptionType::CONFIDENTIAL);
 	}
 }
 
@@ -432,7 +434,7 @@ cl::Event CLProgram::run(std::vector<cl::Event>* events_to_wait_for) {
 	catch (cl::Error &e) {
 		std::stringstream ss;
 		ss << "CL Error: " << e.err() << ": " << e.what();
-		throw OpenCLException(ss.str());
+		throw OpenCLException(ss.str(), MappingExceptionType::CONFIDENTIAL);
 	}
 	cleanScratch();
 }

--- a/src/services/httpservice.cpp
+++ b/src/services/httpservice.cpp
@@ -260,7 +260,7 @@ std::unique_ptr<QueryProcessor::QueryResult> HTTPService::processQuery(Query &qu
 	if(queryResult->isError()) {
 	    //throw, directly catch and throw with nested to get a nested exception structure:
 		try {
-            throw queryResult->getErrorException();
+            throw queryResult->getErrorException().value();
         } catch (...){
 		    std::throw_with_nested(OperatorException("HTTPService: query failed with error.", MappingExceptionType::SAME_AS_NESTED));
 		}

--- a/src/services/httpservice.cpp
+++ b/src/services/httpservice.cpp
@@ -258,7 +258,12 @@ std::unique_ptr<QueryProcessor::QueryResult> HTTPService::processQuery(Query &qu
 	auto queryResult = QueryProcessor::getDefaultProcessor().process(query, true);
 
 	if(queryResult->isError()) {
-		throw OperatorException("HTTPService: query failed with error: " + queryResult->getErrorMessage(), queryResult->getErrorType());
+	    //throw, directly catch and throw with nested to get a nested exception structure:
+		try {
+            throw queryResult->getErrorException();
+        } catch (...){
+		    std::throw_with_nested(OperatorException("HTTPService: query failed with error.", MappingExceptionType::SAME_AS_NESTED));
+		}
 	}
 
 	ProvenanceCollection &provenance = queryResult->getProvenance();

--- a/src/services/httpservice.cpp
+++ b/src/services/httpservice.cpp
@@ -111,7 +111,7 @@ void HTTPService::run(std::streambuf *in, std::streambuf *out, std::streambuf *e
 
 void HTTPService::catchExceptions(HTTPResponseStream& response, const MappingException &me){
     auto exception_type = me.getExceptionType();
-	const bool global_debug = false;//Configuration::get<bool>("global.debug", false);
+	const bool global_debug = Configuration::get<bool>("global.debug", false);
 
 	if(global_debug || exception_type != MappingExceptionType::CONFIDENTIAL){
         Json::Value exceptionJson;

--- a/src/services/httpservice.cpp
+++ b/src/services/httpservice.cpp
@@ -29,7 +29,7 @@ std::unique_ptr<HTTPService> HTTPService::getRegisteredService(const std::string
 	auto map = getRegisteredConstructorsMap();
 	auto it = map->find(name);
 	if (it == map->end())
-		throw ArgumentException(concat("No service named ", name, " is registered"));
+		throw ArgumentException(concat("No service named ", name, " is registered"), MappingExceptionType::PERMANENT);
 
 	auto constructor = it->second;
 
@@ -254,14 +254,14 @@ std::unique_ptr<QueryProcessor::QueryResult> HTTPService::processQuery(Query &qu
 	auto queryResult = QueryProcessor::getDefaultProcessor().process(query, true);
 
 	if(queryResult->isError()) {
-		throw OperatorException("HTTPService: query failed with error: " + queryResult->getErrorMessage());
+		throw OperatorException("HTTPService: query failed with error: " + queryResult->getErrorMessage(), queryResult->getErrorType());
 	}
 
 	ProvenanceCollection &provenance = queryResult->getProvenance();
 
 	for(std::string identifier : provenance.getLocalIdentifiers()) {
 		if(identifier != "" && !user.hasPermission(identifier)) {
-			throw PermissionDeniedException("HTTPService: Permission denied for query result");
+			throw PermissionDeniedException("HTTPService: Permission denied for query result", MappingExceptionType::CONFIDENTIAL);
 		}
 	}
 

--- a/src/services/httpservice.cpp
+++ b/src/services/httpservice.cpp
@@ -165,21 +165,25 @@ void HTTPService::readNestedException(Json::Value &exceptionJson, const MappingE
 
 bool HTTPService::clearExceptionJsonFromConfidential(Json::Value &exceptionJson){
 
-    if(exceptionJson["type"].asString() == "CONFIDENTIAL")
+    const std::string type = exceptionJson["type"].asString();
+
+    if(type == "CONFIDENTIAL")
         return true;
 
     const bool hasNested = exceptionJson.isMember("nested_exception");
 
-    if(exceptionJson["type"].asString() == "SAME_AS_NESTED"){
+    if(type == "SAME_AS_NESTED"){
         if(hasNested)
             return clearExceptionJsonFromConfidential(exceptionJson["nested_exception"]);
         else
             return true; //SAME_AS_NESTED but no nested exception exists, so remove it just in case.
     } else {
         //TRANSIENT or PERMANENT as type. If a nested confidential exception exists, remove it.
-        const bool nestedIsConfidential = clearExceptionJsonFromConfidential(exceptionJson["nested_exception"]);
-        if(hasNested && nestedIsConfidential){
-            exceptionJson.removeMember("nested_exception");
+        if(hasNested){
+            const bool nestedIsConfidential = clearExceptionJsonFromConfidential(exceptionJson["nested_exception"]);
+            if(nestedIsConfidential){
+                exceptionJson.removeMember("nested_exception");
+            }
         }
         return false;
     }

--- a/src/services/httpservice.h
+++ b/src/services/httpservice.h
@@ -94,18 +94,19 @@ class HTTPService {
 
 		static void run(std::streambuf *in, std::streambuf *out, std::streambuf *err);
 		static void run(std::streambuf *in, std::streambuf *out, std::streambuf *err, FCGX_Request & request);
-	public:
+	private:
         /**
-         * Catches MappingExceptions and sends the exceptions nested structure as Json response.
+         * Catches MappingExceptions and sends the exceptions nested structure as Json http response.
          */
 		static void catchExceptions(HTTPResponseStream& response, const MappingException &e);
 		/**
-		 * Reads an exception into the exceptionJson and calls method recursively for nested exception.
+		 * Writes info of the exception into the exceptionJson object and calls
+		 * method recursively for nested exceptions.
 		 */
         static void readNestedException(Json::Value &exceptionJson, const MappingException &me);
 		/**
-		 * Clears confidential exceptions from the response json, including exceptions flaged as SAME_AS_NESTED when the child is CONFIDENTIAL.
-		 * If root element is CONFIDENTIAL the calling function has to handle the removing.
+		 * Clears confidential exceptions from the response json recursively, including exceptions flagged as SAME_AS_NESTED when
+		 * the child is CONFIDENTIAL. If root element is CONFIDENTIAL the calling function has to handle the removing.
 		 * @return if the parameter Json::Value is CONFIDENTIAL or SAME_AS_NESTED and the nested is CONFIDENTIAL.
 		 */
 		static bool clearExceptionJsonFromConfidential(Json::Value &exceptionJson);

--- a/src/services/httpservice.h
+++ b/src/services/httpservice.h
@@ -94,15 +94,21 @@ class HTTPService {
 
 		static void run(std::streambuf *in, std::streambuf *out, std::streambuf *err);
 		static void run(std::streambuf *in, std::streambuf *out, std::streambuf *err, FCGX_Request & request);
-	private:
+	public:
         /**
-         * Catches MappingExceptions and send the exceptions nested structure as Json response.
+         * Catches MappingExceptions and sends the exceptions nested structure as Json response.
          */
 		static void catchExceptions(HTTPResponseStream& response, const MappingException &e);
 		/**
-		 * Reads an exception into the exceptionJson and calls method recursivley for nested exception.
+		 * Reads an exception into the exceptionJson and calls method recursively for nested exception.
 		 */
-        static void readNestedException(Json::Value &exceptionJson, const MappingException &me, const bool global_debug);
+        static void readNestedException(Json::Value &exceptionJson, const MappingException &me);
+		/**
+		 * Clears confidential exceptions from the response json, including exceptions flaged as SAME_AS_NESTED when the child is CONFIDENTIAL.
+		 * If root element is CONFIDENTIAL the calling function has to handle the removing.
+		 * @return if the parameter Json::Value is CONFIDENTIAL or SAME_AS_NESTED and the nested is CONFIDENTIAL.
+		 */
+		static bool clearExceptionJsonFromConfidential(Json::Value &exceptionJson);
 };
 
 

--- a/src/services/httpservice.h
+++ b/src/services/httpservice.h
@@ -94,6 +94,15 @@ class HTTPService {
 
 		static void run(std::streambuf *in, std::streambuf *out, std::streambuf *err);
 		static void run(std::streambuf *in, std::streambuf *out, std::streambuf *err, FCGX_Request & request);
+	private:
+        /**
+         * Catches MappingExceptions and send the exceptions nested structure as Json response.
+         */
+		static void catchExceptions(HTTPResponseStream& response, const MappingException &e);
+		/**
+		 * Reads an exception into the exceptionJson and calls method recursivley for nested exception.
+		 */
+        static void readNestedException(Json::Value &exceptionJson, const MappingException &me, const bool global_debug);
 };
 
 

--- a/src/util/csv_source_util.cpp
+++ b/src/util/csv_source_util.cpp
@@ -229,7 +229,7 @@ void CSVSourceUtil::readAnyCollection(SimpleFeatureCollection *collection, std::
 		catch (const std::exception &e) {
 			switch(errorHandling) {
 				case ErrorHandling::ABORT:
-					throw OperatorException(concat("Geometry in CSV could not be parsed: '", x_str, "', '", y_str, "' ", e.what()));
+					std::throw_with_nested(OperatorException(concat("Geometry in CSV could not be parsed: '", x_str, "', '", y_str, "' "), MappingExceptionType::SAME_AS_NESTED));
 				case ErrorHandling::SKIP:
 					continue;
 				case ErrorHandling::KEEP:

--- a/src/util/exceptions.h
+++ b/src/util/exceptions.h
@@ -22,6 +22,13 @@ public:
 
     }
 
+    /**
+     * Constructor without arguments, type is set to SAME_AS_NESTED
+     */
+    MappingException() : std::runtime_error(""), type(MappingExceptionType::SAME_AS_NESTED){
+
+    }
+
     const MappingExceptionType getExceptionType() const {
         return type;
     }

--- a/src/util/exceptions.h
+++ b/src/util/exceptions.h
@@ -5,11 +5,40 @@
 
 #include <stdexcept>
 
+enum class MappingExceptionType{
+    TRANSIENT,
+    PERMANENT,
+    CONFIDENTIAL,
+    SAME_AS_NESTED
+};
 
-#define _CUSTOM_EXCEPTION_CLASS_PARENT(C, PARENT) class C : public PARENT { public: C(const std::string &msg) : PARENT(#C ": " + msg) {}}
+/**
+ *
+ */
+class MappingException : public std::runtime_error {
+public:
+    MappingException(const std::string &msg, const MappingExceptionType type)
+            : std::runtime_error(msg), type(type) {
+
+    }
+
+    const MappingExceptionType getExceptionType() const {
+        return type;
+    }
+
+private:
+    const MappingExceptionType type;
+};
+
+/**
+ * Macro creating the exception classes. Important here: The MappingExceptionType is set as a default parameter
+ * to CONFIDENTAL, so that not every exception usage at once has to be adapted. CONFIDENTAL is the default, so that
+ * error information that can be shared has to shared explicitly.
+ */
+#define _CUSTOM_EXCEPTION_CLASS_PARENT(C, PARENT) class C : public PARENT { public: C(const std::string &msg, const MappingExceptionType type = MappingExceptionType::CONFIDENTIAL) : PARENT(#C ": " + msg, type) {}}
 
 // This is just some magic to get around the fact that macros cannot have default parameters
-#define _CUSTOM_EXCEPTION_CLASS_DEFAULT(C) _CUSTOM_EXCEPTION_CLASS_PARENT(C, std::runtime_error)
+#define _CUSTOM_EXCEPTION_CLASS_DEFAULT(C) _CUSTOM_EXCEPTION_CLASS_PARENT(C, MappingException)
 
 #define _CUSTOM_EXCEPTION_CLASS_GET_3RD_PARAM(p1, p2, p3, ...) p3
 #define _CUSTOM_EXCEPTION_CLASS_CHOOSER(...) _CUSTOM_EXCEPTION_CLASS_GET_3RD_PARAM(__VA_ARGS__, _CUSTOM_EXCEPTION_CLASS_PARENT, _CUSTOM_EXCEPTION_CLASS_DEFAULT, 0)

--- a/src/util/exceptions.h
+++ b/src/util/exceptions.h
@@ -42,7 +42,9 @@ private:
  * to CONFIDENTAL, so that not every exception usage has to be adapted at once. CONFIDENTAL is the default, so that
  * error information has to shared explicitly.
  */
-#define _CUSTOM_EXCEPTION_CLASS_PARENT(C, PARENT) class C : public PARENT { public: C(const std::string &msg, const MappingExceptionType type = MappingExceptionType::CONFIDENTIAL) : PARENT(#C ": " + msg, type) {}}
+#define _CUSTOM_EXCEPTION_CLASS_PARENT(C, PARENT) class C : public PARENT { \
+    public: C(const std::string &msg, const MappingExceptionType type = MappingExceptionType::CONFIDENTIAL) : PARENT(#C ": " + msg, type) {} \
+    public: C() : PARENT() {}}
 
 // This is just some magic to get around the fact that macros cannot have default parameters
 #define _CUSTOM_EXCEPTION_CLASS_DEFAULT(C) _CUSTOM_EXCEPTION_CLASS_PARENT(C, MappingException)
@@ -72,6 +74,7 @@ _CUSTOM_EXCEPTION_CLASS(FeatureException);
 _CUSTOM_EXCEPTION_CLASS(TimeParseException);
 _CUSTOM_EXCEPTION_CLASS(PermissionDeniedException);
 _CUSTOM_EXCEPTION_CLASS(NoRasterForGivenTimeException);
+_CUSTOM_EXCEPTION_CLASS(ProcessingException);
 
 // Added Micha
 _CUSTOM_EXCEPTION_CLASS(CacheException);

--- a/src/util/exceptions.h
+++ b/src/util/exceptions.h
@@ -17,8 +17,8 @@ enum class MappingExceptionType{
  */
 class MappingException : public std::runtime_error {
 public:
-    MappingException(const std::string &msg, const MappingExceptionType type)
-            : std::runtime_error(msg), type(type) {
+    MappingException(const std::string &msg, const MappingExceptionType type) : std::runtime_error(msg), type(type)
+    {
 
     }
 
@@ -32,8 +32,8 @@ private:
 
 /**
  * Macro creating the exception classes. Important here: The MappingExceptionType is set as a default parameter
- * to CONFIDENTAL, so that not every exception usage at once has to be adapted. CONFIDENTAL is the default, so that
- * error information that can be shared has to shared explicitly.
+ * to CONFIDENTAL, so that not every exception usage has to be adapted at once. CONFIDENTAL is the default, so that
+ * error information has to shared explicitly.
  */
 #define _CUSTOM_EXCEPTION_CLASS_PARENT(C, PARENT) class C : public PARENT { public: C(const std::string &msg, const MappingExceptionType type = MappingExceptionType::CONFIDENTIAL) : PARENT(#C ": " + msg, type) {}}
 


### PR DESCRIPTION
This PR contains:

* MappingException as base type for the existing exceptions of mapping, containing a field MappingExceptionType flagging them as `TRANSIENT`,`PERMANENT`, `CONFIDENTIAL`, `SAME_AS_NESTED` (see `exceptions.h`).
* Exception handling in HTTPService overhauled, responding with exception information as Json. If the exceptions are not flagged as CONFIDENTIAL.
* the QueryResult of the QueryProcessor saves the exception type, so this information does not get lost.
* Some execption adjustments. But most of the changes will come in a separate pull request when this one is handled.