### PR TITLE
Bug fix in OGR Source feature filtering

### DIFF
--- a/src/util/ogr_source_util.cpp
+++ b/src/util/ogr_source_util.cpp
@@ -166,10 +166,11 @@ void OGRSourceUtil::readAnyCollection(const QueryRectangle &rect,
                 time_and_attribute_success = readAttributesIntoCollection(collection->feature_attributes, attributeDefn,
                                                                           feature.get(), featureCount);
 
-            //false means that attribute or time could not be written and errorhandling is SKIP: the already inserted feature has to be removed
+            // false means that attribute or time could not be written and errorhandling is SKIP:
+            // the already inserted feature has to be removed, rest of loop can be skipped.
             if (!time_and_attribute_success) {
-                success = false;
                 collection->removeLastFeature();
+                continue;
             }
         }
 


### PR DESCRIPTION
When error handling was `abort` and a feature was filtered due to its time, the whole query aborted with an exception. But it should just continue with the next attribute.