### PR TITLE
Boost filesystem for path concatenation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -220,8 +220,8 @@ target_link_libraries(mapping_core_base_lib ${GEOS_LIBRARY})
 target_link_libraries(mapping_core_base_lib geos) # TODO: extend find file for c++ lib
 target_include_directories(mapping_core_base_lib PRIVATE ${GEOS_INCLUDE_DIR})
 
-find_package(Boost COMPONENTS date_time REQUIRED)
-target_link_libraries(mapping_core_base_lib Boost::date_time)
+find_package(Boost COMPONENTS date_time filesystem REQUIRED)
+target_link_libraries(mapping_core_base_lib Boost::date_time Boost::filesystem)
 target_include_directories(mapping_core_base_lib PRIVATE ${Boost_INCLUDE_DIRS})
 
 find_package(GDAL REQUIRED)

--- a/src/rasterdb/backend_local.cpp
+++ b/src/rasterdb/backend_local.cpp
@@ -59,12 +59,6 @@ LocalRasterDBBackend::~LocalRasterDBBackend() {
 	cleanup();
 }
 
-static bool has_suffix(const std::string &str, const std::string &suffix) {
-	if (suffix.length() > str.length())
-		return false;
-	return str.compare(str.length() - suffix.length(), suffix.length(), suffix) == 0;
-}
-
 std::vector<std::string> LocalRasterDBBackend::enumerateSources() {
 	namespace bf = boost::filesystem;
 
@@ -79,10 +73,12 @@ std::vector<std::string> LocalRasterDBBackend::enumerateSources() {
 		auto file = (*it).path();
 		if(!bf::is_regular_file(file))
 			continue;
-		auto name = file.filename().string();
 
-		if (has_suffix(name, suffix))
+		auto file_ext = bf::extension(file);
+		if(file_ext == suffix){
+			auto name = file.filename().string();
 			sourcenames.push_back(name.substr(0, name.length() - suffix.length()));
+		}
 	}
 	return sourcenames;
 }

--- a/src/util/configuration.cpp
+++ b/src/util/configuration.cpp
@@ -6,6 +6,7 @@
 #include <pwd.h>
 #include <unistd.h>
 #include <string.h>
+#include <boost/filesystem.hpp>
 
 extern char **environ;
 
@@ -119,9 +120,8 @@ void Configuration::loadFromDefaultPaths() {
 
     auto homedir = getHomeDirectory();
     if (homedir && strlen(homedir) > 0) {
-        std::string path = "";
-        path += homedir;
-        path += "/mapping.conf";
+        boost::filesystem::path path(homedir);
+        path /= "mapping.conf";
         loadFromFile(path.c_str());
     }
 

--- a/src/util/gdal_source_datasets.cpp
+++ b/src/util/gdal_source_datasets.cpp
@@ -24,15 +24,16 @@ std::vector<std::string> GDALSourceDataSets::getDataSetNames() {
         auto file = (*it).path();
         if(!bf::is_regular_file(file))
             continue;
-        auto filename = file.filename().string();
 
-        ///check if file ends with the suffix
-        bool found = filename.find(suffix, filename.length() - suffix_length)  != std::string::npos;
+        //check if file ends with the suffix
+        const std::string file_ext = bf::extension(file);
 
-        if (found) {
-            std::string dataSetName = filename.substr(0, filename.length() - suffix_length);
+        if(suffix == file_ext){
+            const std::string filename = file.filename().string();
+            const std::string dataSetName = filename.substr(0, filename.length() - suffix_length);
             dataSetNames.push_back(dataSetName);
         }
+
     }
     return dataSetNames;
 }

--- a/src/util/gdal_timesnap.cpp
+++ b/src/util/gdal_timesnap.cpp
@@ -1,4 +1,5 @@
 #include "gdal_timesnap.h"
+#include <boost/filesystem.hpp>
 
 constexpr int MAX_FILE_NAME_LENGTH = 255;
 
@@ -213,7 +214,9 @@ GDALTimesnap::GDALDataLoadingInfo GDALTimesnap::getDataLoadingInfo(Json::Value d
     CrsId crsId = CrsId::from_srs_string(coords.get("crs", "").asString());
 
 
-	return GDALDataLoadingInfo(path + "/" + fileName, channel,
+    boost::filesystem::path file_path(path);
+    file_path /= fileName;
+	return GDALDataLoadingInfo(file_path.string(), channel,
                                TemporalReference(TIMETYPE_UNIX, time_start_mapping, time_end_mapping),
                                crsId, nodata, unit);
 }

--- a/src/util/gdal_timesnap.h
+++ b/src/util/gdal_timesnap.h
@@ -4,7 +4,6 @@
 #include <map>
 #include <ctime>
 #include <json/json.h>
-#include <dirent.h>
 #include <sstream>
 #include <fstream>
 #include <gdal.h>

--- a/src/util/ogr_source_datasets.cpp
+++ b/src/util/ogr_source_datasets.cpp
@@ -1,26 +1,27 @@
 
-
-#include <dirent.h>
+#include <boost/filesystem.hpp>
+#include <boost/range/iterator_range.hpp>
 #include "ogr_source_datasets.h"
 #include "configuration.h"
 #include "ogr_source_util.h"
 
 std::vector<std::string> OGRSourceDatasets::getDatasetNames(){
-    const std::string path = Configuration::get<std::string>("ogrsource.files.path");
+    namespace bf = boost::filesystem;
+    bf::path path = Configuration::get<std::string>("ogrsource.files.path");
 
-    struct dirent *entry;
-    DIR *dir = opendir(path.c_str());
+    if(!bf::is_directory(path))
+        throw ArgumentException("ogrsource.files.path in configuration is not valid directory");
 
-    if (dir == nullptr) {
-        throw MustNotHappenException("OGR Source Datasets: Directory for OGR files could not be found -> " + path);
-    }
 
     std::vector<std::string> filenames;
-    std::string suffix(".json");
-    size_t suffix_length = suffix.length();
+    const std::string suffix(".json");
+    const size_t suffix_length = suffix.length();
 
-    while ((entry = readdir(dir)) != nullptr) {
-        std::string filename = entry->d_name;
+    for(auto it = bf::directory_iterator(path); it != bf::directory_iterator{}; ++it){
+        auto file = (*it).path();
+        if(!bf::is_regular_file(file))
+            continue;
+        auto filename = file.filename().string();
 
         //check if file ends with the suffix
         bool found = filename.find(suffix, filename.length() - suffix_length)  != std::string::npos;
@@ -30,9 +31,6 @@ std::vector<std::string> OGRSourceDatasets::getDatasetNames(){
             filenames.push_back(dataSetName);
         }
     }
-
-    closedir(dir);
-
     return filenames;
 }
 
@@ -110,9 +108,10 @@ Json::Value OGRSourceDatasets::getDatasetListing(const std::string &dataset_name
 
 Json::Value OGRSourceDatasets::getDatasetDescription(const std::string &name){
     std::string directory = Configuration::get<std::string>("ogrsource.files.path");
-    std::string filename = directory + "/" + name + ".json";
+    boost::filesystem::path file_path(directory);
+    file_path /= name + ".json";
 
-    std::ifstream file(filename);
+    std::ifstream file(file_path.string());
     if (!file.is_open()) {
         throw ArgumentException("OGR Source Datasets: File with given name not found -> " + name);
     }

--- a/src/util/ogr_source_datasets.cpp
+++ b/src/util/ogr_source_datasets.cpp
@@ -32,7 +32,7 @@ std::vector<std::string> OGRSourceDatasets::getDatasetNames(){
         }
     }
     return filenames;
-}rasterdb
+}
 
 Json::Value OGRSourceDatasets::getDatasetListing(const std::string &dataset_name){
     Json::Value desc = getDatasetDescription(dataset_name);

--- a/src/util/ogr_source_datasets.cpp
+++ b/src/util/ogr_source_datasets.cpp
@@ -21,13 +21,13 @@ std::vector<std::string> OGRSourceDatasets::getDatasetNames(){
         auto file = (*it).path();
         if(!bf::is_regular_file(file))
             continue;
-        auto filename = file.filename().string();
 
         //check if file ends with the suffix
-        bool found = filename.find(suffix, filename.length() - suffix_length)  != std::string::npos;
+        const std::string file_ext = bf::extension(file);
 
-        if (found) {
-            std::string dataSetName = filename.substr(0, filename.length() - suffix_length);
+        if (suffix == file_ext) {
+            const std::string filename = file.filename().string();
+            const std::string dataSetName = filename.substr(0, filename.length() - suffix_length);
             filenames.push_back(dataSetName);
         }
     }

--- a/src/util/ogr_source_util.cpp
+++ b/src/util/ogr_source_util.cpp
@@ -12,7 +12,6 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <json/json.h>
-#include <dirent.h>
 #include <iostream>
 #include "boost/date_time/posix_time/posix_time.hpp"
 #include <boost/date_time/local_time/local_time.hpp>


### PR DESCRIPTION
This PR replaces string path concatenation with boost filesystems `path` class.
This has the advantage that it does not matter if configuration parameters for directories end on a `/` or not. Boost handles both cases the same.

It also replaces the usages of `dirent` to iterate files in directories with boost filesystem and thus with a modern C++ style.