### PR TITLE
Logging to file

### DIFF
--- a/conf/settings-default.toml
+++ b/conf/settings-default.toml
@@ -68,6 +68,7 @@ location= "tcp:127.0.0.1:10200" # The connection string for the R-Operator to us
 directory="uploader" # The name of the directory where the uploader stores the files
 
 [log]
-logtofile=false #If logs should be written to file instead of error stream
-#logfilelocation="" #Location to store the logs
-logfilelevel="DEBUG" #The maximum level to be logged to file
+logtofile=false # If logs should be written to file instead of error stream
+#logfilelocation="" # Location to store the logs
+logfilelevel="DEBUG" # The maximum level to be logged to file
+cgilogfilename="gci_logs.txt" # The name for CGI log file, that is shared between program instances.

--- a/conf/settings-default.toml
+++ b/conf/settings-default.toml
@@ -66,3 +66,8 @@ location= "tcp:127.0.0.1:10200" # The connection string for the R-Operator to us
 
 [uploader]
 directory="uploader" # The name of the directory where the uploader stores the files
+
+[log]
+logtofile=false #If logs should be written to file instead of error stream
+#logfilelocation="" #Location to store the logs
+logfilelevel="DEBUG" #The maximum level to be logged to file

--- a/src/cgi.cpp
+++ b/src/cgi.cpp
@@ -44,7 +44,12 @@ JPEG32: 120703 (90%)
  * A thread function that handles fcgi request
  */
 void fcgiThread(int fd) {
-	FCGX_Init();
+    std::stringstream id_stream;
+    id_stream << std::this_thread::get_id();
+    std::string thread_id(id_stream.str());
+    Log::debug("Start of fcgiThread. Thread thread_id: " + thread_id);
+
+    FCGX_Init();
 
 	FCGX_Request request;
 
@@ -54,9 +59,10 @@ void fcgiThread(int fd) {
 		fcgi_streambuf streambuf_in(request.in);
 		fcgi_streambuf streambuf_out(request.out);
 		fcgi_streambuf streambuf_err(request.err);
-
+        Log::debug("Thread is running new service: " + thread_id);
 		HTTPService::run(&streambuf_in, &streambuf_out, &streambuf_err, request);
 	}
+    Log::debug("End of fcgiThread. Thread thread_id: " + thread_id);
 }
 
 int main() {

--- a/src/cgi.cpp
+++ b/src/cgi.cpp
@@ -47,7 +47,7 @@ void fcgiThread(int fd) {
     std::stringstream id_stream;
     id_stream << std::this_thread::get_id();
     std::string thread_id(id_stream.str());
-    Log::debug("Start of fcgiThread. Thread thread_id: " + thread_id);
+    Log::debug("Start of thread: " + thread_id);
 
     FCGX_Init();
 
@@ -59,10 +59,12 @@ void fcgiThread(int fd) {
 		fcgi_streambuf streambuf_in(request.in);
 		fcgi_streambuf streambuf_out(request.out);
 		fcgi_streambuf streambuf_err(request.err);
-        Log::debug("Thread is running new service: " + thread_id);
+		Log::setThreadRequestId(request.requestId);
+		Log::debug(concat("New request ", request.requestId, ", on thread ", thread_id));
 		HTTPService::run(&streambuf_in, &streambuf_out, &streambuf_err, request);
+		Log::debug(concat("Finished request ", request.requestId));
 	}
-    Log::debug("End of fcgiThread. Thread thread_id: " + thread_id);
+    Log::debug("End of thread: " + thread_id);
 }
 
 int main() {
@@ -71,6 +73,7 @@ int main() {
 
 	if(Configuration::get<bool>("log.logtofile")){
 		Log::logToFile();
+		Log::logRequestId(true);
 	}
 
 	/*

--- a/src/cgi.cpp
+++ b/src/cgi.cpp
@@ -61,7 +61,11 @@ void fcgiThread(int fd) {
 
 int main() {
 	Configuration::loadFromDefaultPaths();
-	Log::off();
+	Log::streamAndMemoryOff();
+
+	if(Configuration::get<bool>("log.logtofile")){
+		Log::logToFile();
+	}
 
 	/*
 	 * Initialize Cache
@@ -129,4 +133,5 @@ int main() {
 			threads[i].join();
 		}
 	}
+	Log::fileOff();
 }

--- a/src/mapping_manager.cpp
+++ b/src/mapping_manager.cpp
@@ -791,6 +791,9 @@ int main(int argc, char *argv[]) {
 	NopCacheManager cm;
 	CacheManager::init(&cm);
 
+	if(Configuration::get<bool>("log.logtofile")){
+		Log::logToFile();
+	}
 	Log::logToStream(Log::LogLevel::WARN, &std::cerr);
 
 	const char *command = argv[1];

--- a/src/mapping_manager.cpp
+++ b/src/mapping_manager.cpp
@@ -792,7 +792,7 @@ int main(int argc, char *argv[]) {
 	CacheManager::init(&cm);
 
 	if(Configuration::get<bool>("log.logtofile")){
-		Log::logToFile();
+		Log::logToFile(false);
 	}
 	Log::logToStream(Log::LogLevel::WARN, &std::cerr);
 

--- a/src/services/artifact.cpp
+++ b/src/services/artifact.cpp
@@ -6,6 +6,7 @@
 #include "util/exceptions.h"
 #include "util/curl.h"
 #include "util/timeparser.h"
+#include "util/log.h"
 
 #include <cstring>
 #include <sstream>
@@ -62,6 +63,7 @@ void ArtifactService::run() {
 
 		auto session = UserDB::loadSession(params.get("sessiontoken"));
 		auto user = session->getUser();
+		Log::debug("User: " + user.getUserIDString());
 
 		if(request == "create") {
 			std::string type = params.get("type");

--- a/src/services/featurecollectiondb.cpp
+++ b/src/services/featurecollectiondb.cpp
@@ -1,10 +1,10 @@
 
 #include "datatypes/plot.h"
 #include "operators/operator.h"
-
 #include "services/ogcservice.h"
 #include "featurecollectiondb/featurecollectiondb.h"
 #include "util/enumconverter.h"
+#include "util/log.h"
 
 static const std::vector< std::pair<Query::ResultType, std::string> > featureTypeMap = {
 	std::make_pair(Query::ResultType::POINTS, "points"),
@@ -80,6 +80,7 @@ Json::Value FeatureCollectionDBService::metaDataToJson(const FeatureCollectionDB
 void FeatureCollectionDBService::run() {
 	auto session = UserDB::loadSession(params.get("sessiontoken"));
 	auto& user = session->getUser();
+	Log::debug("User: " + user.getUserIDString());
 
 	if(!FeatureCollectionDB::isAvailable()){
 		throw SourceException("FeatureCollectionDB is not available.");

--- a/src/services/httpservice.cpp
+++ b/src/services/httpservice.cpp
@@ -57,6 +57,8 @@ void HTTPService::run(std::streambuf *in, std::streambuf *out, std::streambuf *e
 		auto servicename = params.get("service");
 		auto service = HTTPService::getRegisteredService(servicename, params, response, error);
 
+		Log::debug("Running new service: " + servicename);
+		
 		service->run();
 	}
     catch(const MappingException &e){
@@ -64,6 +66,7 @@ void HTTPService::run(std::streambuf *in, std::streambuf *out, std::streambuf *e
     }
 	catch (const std::exception &e) {
 		error << "Request failed with an exception: " << e.what() << "\n";
+        Log::debug(e.what());
 		if (Configuration::get<bool>("global.debug", false)) {
             response.send500(concat("invalid request: ", e.what()));
         } else {
@@ -93,6 +96,8 @@ void HTTPService::run(std::streambuf *in, std::streambuf *out, std::streambuf *e
 		auto servicename = params.get("service");
 		auto service = HTTPService::getRegisteredService(servicename, params, response, error);
 
+		Log::debug("Running new service: " + servicename);
+
 		service->run();
 	}
     catch(const MappingException &e){
@@ -100,6 +105,7 @@ void HTTPService::run(std::streambuf *in, std::streambuf *out, std::streambuf *e
     }
 	catch (const std::exception &e) {
 		error << "Request failed with an exception: " << e.what() << "\n";
+		Log::debug(e.what());
 		if (Configuration::get<bool>("global.debug", false)) {
             response.send500(concat("invalid request: ", e.what()));
         } else {
@@ -126,6 +132,7 @@ void HTTPService::catchExceptions(HTTPResponseStream& response, const MappingExc
         }
         response.sendHeader("Status", "500 Internal Server Error");
         response.sendJSON(exceptionJson);
+        Log::debug(exceptionJson.asString());
     } else {
         response.send500("invalid request");
     }

--- a/src/services/httpservice.cpp
+++ b/src/services/httpservice.cpp
@@ -71,7 +71,7 @@ void HTTPService::run(std::streambuf *in, std::streambuf *out, std::streambuf *e
         }
 
 	}
-	Log::off();
+	Log::streamAndMemoryOff();
 }
 
 /**
@@ -106,7 +106,7 @@ void HTTPService::run(std::streambuf *in, std::streambuf *out, std::streambuf *e
             response.send500("invalid request");
         }
 	}
-	Log::off();
+	Log::streamAndMemoryOff();
 }
 
 void HTTPService::catchExceptions(HTTPResponseStream& response, const MappingException &me){

--- a/src/services/httpservice.cpp
+++ b/src/services/httpservice.cpp
@@ -46,6 +46,11 @@ void HTTPService::run(std::streambuf *in, std::streambuf *out, std::streambuf *e
 	std::ostream error(err);
 	HTTPResponseStream response(out);
 
+	//read query input to string and log it. reset input istream position to the beginning afterwards.
+	std::string query_string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+	input.seekg(0, std::ios_base::beg);
+	Log::debug(query_string);
+
 	Log::logToStream(Log::LogLevel::WARN, &error);
 	Log::logToMemory(Log::LogLevel::INFO);
 	try {
@@ -84,6 +89,11 @@ void HTTPService::run(std::streambuf *in, std::streambuf *out, std::streambuf *e
 	std::istream input(in);
 	std::ostream error(err);
 	HTTPResponseStream response(out);
+
+	//read query input to string and log it. reset input istream position to the beginning afterwards.
+	std::string query_string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+	input.seekg(0, std::ios_base::beg);
+	Log::debug(query_string);
 
 	Log::logToStream(Log::LogLevel::WARN, &error);
 	Log::logToMemory(Log::LogLevel::INFO);

--- a/src/services/plot.cpp
+++ b/src/services/plot.cpp
@@ -1,7 +1,7 @@
 
 #include "datatypes/plot.h"
 #include "operators/operator.h"
-
+#include "util/log.h"
 #include "services/ogcservice.h"
 
 /*
@@ -24,6 +24,7 @@ REGISTER_HTTP_SERVICE(PlotService, "plot");
 void PlotService::run() {
 	auto session = UserDB::loadSession(params.get("sessiontoken"));
 	auto user = session->getUser();
+	Log::debug("User: " + user.getUserIDString());
 
 	std::string queryString = params.get("query", "");
 	if(queryString == "")

--- a/src/services/provenance.cpp
+++ b/src/services/provenance.cpp
@@ -1,6 +1,7 @@
 
 #include "services/ogcservice.h"
 #include "operators/operator.h"
+#include "util/log.h"
 
 /*
  * This class serves provenance information of a query.
@@ -27,6 +28,7 @@ REGISTER_HTTP_SERVICE(ProvenanceService, "provenance");
 void ProvenanceService::run() {
 	auto session = UserDB::loadSession(params.get("sessiontoken"));
 	auto user = session->getUser();
+	Log::debug("User: " + user.getUserIDString());
 
 	std::string type = params.get("type", "");
 	if(type != "points" && type != "lines" && type != "polygons" && type != "raster") {

--- a/src/services/user.cpp
+++ b/src/services/user.cpp
@@ -9,6 +9,7 @@
 #include <util/gdal_source_datasets.h>
 #include <util/ogr_source_datasets.h>
 #include <boost/filesystem.hpp>
+#include <util/log.h>
 
 /**
  * This class provides user specific methods
@@ -47,6 +48,7 @@ void UserService::run() {
 		// anything except login is only allowed with a valid session, so check for it.
 		auto session = UserDB::loadSession(params.get("sessiontoken"));
 		auto user = session->getUser();
+		Log::debug("User: " + user.getUserIDString());
 
 		if (request == "logout") {
 			session->logout();

--- a/src/services/wcs.cpp
+++ b/src/services/wcs.cpp
@@ -3,6 +3,7 @@
 #include "operators/operator.h"
 #include "datatypes/raster.h"
 #include "util/timeparser.h"
+#include "util/log.h"
 
 /**
  * Implementation of the OGC WCS standard http://www.opengeospatial.org/standards/wcs
@@ -81,6 +82,7 @@ static int getWcsParameterInteger(const std::string &wcsParameterString){
 void WCSService::run() {
 	auto session = UserDB::loadSession(params.get("sessiontoken"));
 	auto user = session->getUser();
+	Log::debug("User: " + user.getUserIDString());
 
 	/*http://www.myserver.org:port/path?
 	 * service=WCS &version=2.0

--- a/src/services/wfs.cpp
+++ b/src/services/wfs.cpp
@@ -6,6 +6,7 @@
 #include "pointvisualization/CircleClusteringQuadTree.h"
 #include "util/timeparser.h"
 #include "util/enumconverter.h"
+#include "util/log.h"
 
 #include <string>
 #include <cmath>
@@ -90,6 +91,7 @@ void WFSService::getCapabilities() {
 void WFSService::getFeature() {
 	auto session = UserDB::loadSession(params.get("sessiontoken"));
 	auto user = session->getUser();
+	Log::debug("User: " + user.getUserIDString());
 
 	if(!params.hasParam("typenames"))
 		throw ArgumentException("WFSService: typeNames parameter not specified");

--- a/src/services/wms.cpp
+++ b/src/services/wms.cpp
@@ -27,6 +27,7 @@ REGISTER_HTTP_SERVICE(WMSService, "WMS");
 void WMSService::run() {
 	auto session = UserDB::loadSession(params.get("sessiontoken"));
 	auto user = session->getUser();
+	Log::debug("User: " + user.getUserIDString());
 
 	bool debug = params.getBool("debug", Configuration::get<bool>("global.debug", false));
 	auto query_crsId = parseCrsId(params, "crs");

--- a/src/uploader/uploader_cgi.cpp
+++ b/src/uploader/uploader_cgi.cpp
@@ -7,7 +7,7 @@
 
 int main() {
     Configuration::loadFromDefaultPaths();
-    Log::off();
+    Log::streamAndMemoryOff();
     UserDB::initFromConfiguration();
 
     UploadService service(std::cin.rdbuf(), std::cout.rdbuf(), std::cerr.rdbuf());

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -69,6 +69,22 @@ public:
 	static void debug(const std::string &msg);
 	static void trace(const char *msg, ...);
 	static void trace(const std::string &msg);
+
+	/**
+	 * Sets the thread_local variable current_request_id. If logRequestId is set to true
+	 * the request id of the current thread will be written in front of the log messages.
+	 */
+	static void setThreadRequestId(int id);
+
+    static bool log_request_id;
+
+	/**
+	 * Set if the current request id will be written before logs. Call setThreadRequestId
+	 * to set the current id for the calling thread.
+	 */
+	static void logRequestId(bool value);
+
+	static thread_local int current_request_id;
 };
 
 #endif /* LOG_H_ */

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 #include <ostream>
+#include <fstream>
 #include <stdarg.h>
 
 
@@ -22,6 +23,13 @@ public:
 	enum class LogLevel {
 		OFF, ERROR, WARN, INFO, DEBUG, TRACE
 	};
+
+	/**
+	 * Logs to a file on disc. Parameters can be set in config (enable/disable, file location, log level).
+	 * It will not be disabled with the streamAndMemoryOff() call [former off()].
+	 * This allows logging on fcgi level without interfering with memory and stream logging.
+	 */
+	static void logToFile();
 
 	/**
 	 * Logs to a stream, usually std::cerr
@@ -42,9 +50,14 @@ public:
 	static std::vector<std::string> getMemoryMessages();
 
 	/**
-	 * Turns logging off.
+	 * Turns stream and memory logging off.
 	 */
-	static void off();
+	static void streamAndMemoryOff();
+
+    /**
+     * Turns file logging off.
+     */
+    static void fileOff();
 
 	static void error(const char *msg, ...);
 	static void error(const std::string &msg);

--- a/src/util/log.h
+++ b/src/util/log.h
@@ -25,11 +25,12 @@ public:
 	};
 
 	/**
-	 * Logs to a file on disc. Parameters can be set in config (enable/disable, file location, log level).
+	 * Logs to a file on disc. Parameters can be set in config (enable/disable, file location, log level, cgi log file name).
 	 * It will not be disabled with the streamAndMemoryOff() call [former off()].
 	 * This allows logging on fcgi level without interfering with memory and stream logging.
+	 * @param isCgi If isCgi is true every instance of mapping_cgi will log into the same file, else a new file will be created for this fcgi program instance.
 	 */
-	static void logToFile();
+	static void logToFile(bool isCgi);
 
 	/**
 	 * Logs to a stream, usually std::cerr
@@ -74,7 +75,7 @@ public:
 	 * Sets the thread_local variable current_request_id. If logRequestId is set to true
 	 * the request id of the current thread will be written in front of the log messages.
 	 */
-	static void setThreadRequestId(int id);
+	static void setThreadRequestId(long id);
 
     static bool log_request_id;
 
@@ -84,7 +85,7 @@ public:
 	 */
 	static void logRequestId(bool value);
 
-	static thread_local int current_request_id;
+	static thread_local long current_request_id;
 };
 
 #endif /* LOG_H_ */


### PR DESCRIPTION
Added the ability to log to files. This is an additional logging channel, so stream and memory logging stay separate and work as before. Parameters for file logging can be set in the config.

If preferred I could also change this and incorporate the file logging into stream logging. This would need a few if-else blocks in the HTTPService, so that the file logging is not turned off in between executing different services.

I added debug log calls for the start and end of fcgi threads, including the threads ID. The execution of services and the users id are logged.