### PR TITLE
T689 and T690

### DIFF
--- a/test/systemtests/data/ogr_files/nyu.json
+++ b/test/systemtests/data/ogr_files/nyu.json
@@ -13,13 +13,44 @@
 
     "layers" : {    	       
         "sdr:nyu_2451_35023" : {
-            "time" : "none"
+            "time" : "none",
+            "columns" : {
+                "textual" : [
+                    "exsdesc",
+                    "f_code",
+                    "f_codedesc"
+                ],
+                "numeric" : [
+                    "tile_id",
+                    "end_id"
+                ]
+            }
         },
         "sdr:nyu_2451_35659" : {
-            "time" : "none"            
+            "time" : "none",
+            "columns" : {
+                "textual" : [
+                    "f_code",
+                    "f_codedesc",
+                    "textstring"
+                ],
+                "numeric" : [
+                    "tile_id",
+                    "txt_id"
+                ]
+            }
         },
         "sdr:nyu_2451_38681" : {
-            "time" : "none"
+            "time" : "none",
+            "columns" : {
+                "textual" : [
+                    "type",
+                    "link"
+                ],
+                "numeric" : [
+                    "current"
+                ]
+            }
         }
     }
 }

--- a/test/systemtests/data/ogr_files/ogr_source_dataset1.json
+++ b/test/systemtests/data/ogr_files/ogr_source_dataset1.json
@@ -4,17 +4,34 @@
     "on_error" : "keep",
     "description" : "It's all about the cities",
     "time": "start",
-    "duration" : 2678400,   
+    "columns" : {
+                "x" : "wkt",
+                "time1" : "time_start",
+                "numeric" : [
+                    "population"
+                ],
+                "textual" : [
+                    "name",
+                    "is_in"
+                ]
+            },
+    "duration" : 2678400,
     "layers" : {
-        "osm_large_cities" : {                        
+        "osm_large_cities" : {
             "columns" : {
                 "x" : "wkt",
-                "time1" : "time_start"                             
+                "time1" : "time_start",
+                "numeric" : [
+                    "population"
+                ],
+                "textual" : [
+                    "name"
+                ]
             },
             "time1_format" : {
                 "format" : "iso"
-            },       
-            "geometry_type" : "points"            
+            },
+            "geometry_type" : "points"
         }
     }
 }

--- a/test/systemtests/data/ogr_files/ogr_source_dataset2.json
+++ b/test/systemtests/data/ogr_files/ogr_source_dataset2.json
@@ -5,7 +5,15 @@
     "layers" : {
     	"ne_10m_ports" : {
     		"time" : "none",
-    		"description" : "Ahoi"
+    		"description" : "Ahoi",
+    		"columns" : {
+    			"textual" : [
+    				"website"
+    			],
+    			"numeric" : [
+					"natlscale"
+    			]
+    		}
     	}
     }
 }


### PR DESCRIPTION
First commit adresses [T689](https://dbs-projects.mathematik.uni-marburg.de/T689). I fixed in OGRDatasets the listing: before all attributes present in the file were returned as possible attributes. Now only those attributes are returned, that are listed in the layer definition or in the dataset definition (if layer has no columns definition).

Second commit adresses [T690](https://dbs-projects.mathematik.uni-marburg.de/T690). When no `%%%TIME_STRING%%%` placeholder is present in the filename, it will not try to replace it anymore.